### PR TITLE
Fix typo & add citation file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,17 @@
+cff-version: 0.1.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Rozemberczki"
+  given-names: "Benedek"
+  orcid: "https://orcid.org/0000-0000-0000-0000"
+- family-names: "Nilsson"
+  given-names: "Sebastian"
+  orcid: "https://orcid.org/0000-0000-0000-0000"
+- family-names: "Edwards"
+  given-names: "Gavin"
+  orcid: "https://orcid.org/0000-0003-0630-5529"
+title: "RexMex"
+version: 0.1.0
+# doi: 10.5281/zenodo.1234
+# date-released: 2021-12-01
+url: "https://github.com/AstraZeneca/rexmex"

--- a/README.md
+++ b/README.md
@@ -178,6 +178,14 @@ $ pytest ./tests/integration -cov rexmex/
 
 --------------------------------------------------------------------------------
 
+**Citation**
+
+If you use RexMex in a scientific publication, we would appreciate citations. Please see GitHubs built in citation tool.
+
+
+
+--------------------------------------------------------------------------------
+
 **License**
 
 - [Apache-2.0 License](https://github.com/AZ-AI/rexmex/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ metric_set = ClassificationMetricSet()
 
 score_card = ScoreCard(metric_set)
 
-report = score_card.generate_report(scores, groupping=["source_group"])
+report = score_card.generate_report(scores, grouping=["source_group"])
 ```
 
 --------------------------------------------------------------------------------

--- a/rexmex/scorecard.py
+++ b/rexmex/scorecard.py
@@ -26,7 +26,7 @@ class ScoreCard(object):
         performance_metrics = pd.DataFrame.from_dict(performance_metrics)
         return performance_metrics
 
-    def generate_report(self, scores_to_evaluate: pd.DataFrame, groupping: List[str] = None) -> pd.DataFrame:
+    def generate_report(self, scores_to_evaluate: pd.DataFrame, grouping: List[str] = None) -> pd.DataFrame:
         """
         A method to calculate (aggregated) performance metrics based
         on a dataframe of ground truth and predictions. It assumes that the dataframe has the `y_true`
@@ -35,12 +35,12 @@ class ScoreCard(object):
         Args:
             scores_to_evaluate (pd.DataFrame): A dataframe with the scores and ground-truth - it has the `y_true`
             and `y_score` keys.
-            groupping (list): A list of performance groupping variable names.
+            grouping (list): A list of performance grouping variable names.
         Returns:
             report (pd.DataFrame): The performance report.
         """
-        if groupping is not None:
-            scores_to_evaluate = scores_to_evaluate.groupby(groupping)
+        if grouping is not None:
+            scores_to_evaluate = scores_to_evaluate.groupby(grouping)
             report = scores_to_evaluate.apply(lambda group: self._get_performance_metrics(group.y_true, group.y_score))
         else:
             report = self._get_performance_metrics(scores_to_evaluate.y_true, scores_to_evaluate.y_score)

--- a/tests/integration/test_aggregation.py
+++ b/tests/integration/test_aggregation.py
@@ -19,12 +19,12 @@ class TestMetricAggregation(unittest.TestCase):
         assert performance_metrics.shape == (1, 11)
 
         performance_metrics = score_card.generate_report(
-            self.scores, groupping=["source_group"]
+            self.scores, grouping=["source_group"]
         )
         assert performance_metrics.shape == (5, 11)
 
         performance_metrics = score_card.generate_report(
-            self.scores, groupping=["source_group", "target_group"]
+            self.scores, grouping=["source_group", "target_group"]
         )
         assert performance_metrics.shape == (20, 11)
 
@@ -37,12 +37,12 @@ class TestMetricAggregation(unittest.TestCase):
         assert performance_metrics.shape == (1, 7)
 
         performance_metrics = score_card.generate_report(
-            self.scores, groupping=["source_group"]
+            self.scores, grouping=["source_group"]
         )
         assert performance_metrics.shape == (5, 7)
 
         performance_metrics = score_card.generate_report(
-            self.scores, groupping=["source_group", "target_group"]
+            self.scores, grouping=["source_group", "target_group"]
         )
         assert performance_metrics.shape == (20, 7)
 
@@ -54,11 +54,11 @@ class TestMetricAggregation(unittest.TestCase):
         assert performance_metrics.shape == (1, 18)
 
         performance_metrics = score_card.generate_report(
-            self.scores, groupping=["source_group"]
+            self.scores, grouping=["source_group"]
         )
         assert performance_metrics.shape == (5, 18)
 
         performance_metrics = score_card.generate_report(
-            self.scores, groupping=["source_group", "target_group"]
+            self.scores, grouping=["source_group", "target_group"]
         )
         assert performance_metrics.shape == (20, 18)


### PR DESCRIPTION
# Summary
 
Fix typo where 'grouping' was misspelt 'groupping' and test an initial citation file 
 
- [x] Code passes all tests
- [x] Unit tests provided for these changes
- [x] Documentation and docstrings added for these changes

## Changes 

* Fix typo where 'grouping' was misspelt 'groupping'
* test adding an initial citation file 