### PR TITLE
Add mean rank and geometric mean rank

### DIFF
--- a/rexmex/metrics/ranking.py
+++ b/rexmex/metrics/ranking.py
@@ -5,9 +5,9 @@ from scipy import stats
 from sklearn.metrics.pairwise import cosine_similarity
 import itertools
 from sklearn.metrics import dcg_score, ndcg_score
-from typing import Variable
+from typing import TypeVar
 
-X = Variable(X)
+X = TypeVar("X")
 
 
 def reciprocal_rank(relevant_item: any, recommendation: List) -> float:

--- a/rexmex/metrics/ranking.py
+++ b/rexmex/metrics/ranking.py
@@ -44,6 +44,46 @@ def mean_reciprocal_rank(relevant_items: List, recommendation: List):
     return np.mean(reciprocal_ranks)
 
 
+def _rank(relevant_item: any, recommendation: List) -> float:
+    # calculate the mean rank of an item
+    assert relevant_item in recommendation
+    for i, item in enumerate(recommendation):
+        if item == relevant_item:
+            return i + 1.0
+
+
+def mean_rank(relevant_items: List, recommendation: List) -> float:
+    """
+    Calculate the arithmetic mean rank (MR) of items in a ranked list.
+
+    Args:
+        relevant_items (array-like): An N x 1 array of relevant items.
+        predicted (array-like):  An N x 1 array of ordered items.
+    Returns:
+        MR (float): The mean rank of the relevant items in a predicted.
+    """
+    return np.mean([
+        _rank(item, recommendation)
+        for item in relevant_items
+    ])
+
+
+def gmean_rank(relevant_items: List, recommendation: List) -> float:
+    """
+    Calculate the geometric mean rank (GMR) of items in a ranked list.
+
+    Args:
+        relevant_items (array-like): An N x 1 array of relevant items.
+        predicted (array-like):  An N x 1 array of ordered items.
+    Returns:
+        GMR (float): The mean reciprocal rank of the relevant items in a predicted.
+    """
+    return stats.gmean([
+        _rank(item, recommendation)
+        for item in relevant_items
+    ])
+
+
 def average_precision_at_k(relevant_items: np.array, recommendation: np.array, k=10):
     """
     Calculate the average precision at k (AP@K) of items in a ranked list.

--- a/rexmex/metrics/ranking.py
+++ b/rexmex/metrics/ranking.py
@@ -7,8 +7,8 @@ import itertools
 from sklearn.metrics import dcg_score, ndcg_score
 from typing import Variable
 
-
 X = Variable(X)
+
 
 def reciprocal_rank(relevant_item: any, recommendation: List) -> float:
     """
@@ -55,7 +55,7 @@ def rank(relevant_item: X, recommendation: Sequence[X]) -> float:
         relevant_item: a target item in the predicted list of items.
         recommendation: An N x 1 sequence of predicted items.
     Returns:
-        rank (float): The rank of the item.
+        : The rank of the item.
     """
     assert relevant_item in recommendation
     for i, item in enumerate(recommendation):
@@ -71,7 +71,7 @@ def mean_rank(relevant_items: Sequence[X], recommendation: Sequence[X]) -> float
         relevant_items: An N x 1 sequence of relevant items.
         predicted:  An N x 1 sequence of ordered items.
     Returns:
-        MR (float): The mean rank of the relevant items in a predicted.
+        : The mean rank of the relevant items in a predicted.
     """
     return np.mean([
         rank(item, recommendation)
@@ -87,7 +87,7 @@ def gmean_rank(relevant_items: Sequence[X], recommendation: Sequence[X]) -> floa
         relevant_items: An N x 1 sequence of relevant items.
         predicted:  An N x 1 sequence of ordered items.
     Returns:
-        GMR (float): The mean reciprocal rank of the relevant items in a predicted.
+        : The mean reciprocal rank of the relevant items in a predicted.
     """
     return stats.gmean([
         rank(item, recommendation)

--- a/rexmex/metrics/ranking.py
+++ b/rexmex/metrics/ranking.py
@@ -44,8 +44,16 @@ def mean_reciprocal_rank(relevant_items: List, recommendation: List):
     return np.mean(reciprocal_ranks)
 
 
-def _rank(relevant_item: any, recommendation: List) -> float:
-    # calculate the mean rank of an item
+def rank(relevant_item: any, recommendation: List) -> float:
+    """
+    Calculate the rank of an item in a ranked list of items.
+
+    Args:
+        relevant_item (any): a target item in the predicted list of items.
+        recommendation (array-like): An N x 1 predicted of items.
+    Returns:
+        rank (float): The rank of the item.
+    """
     assert relevant_item in recommendation
     for i, item in enumerate(recommendation):
         if item == relevant_item:
@@ -63,7 +71,7 @@ def mean_rank(relevant_items: List, recommendation: List) -> float:
         MR (float): The mean rank of the relevant items in a predicted.
     """
     return np.mean([
-        _rank(item, recommendation)
+        rank(item, recommendation)
         for item in relevant_items
     ])
 
@@ -79,7 +87,7 @@ def gmean_rank(relevant_items: List, recommendation: List) -> float:
         GMR (float): The mean reciprocal rank of the relevant items in a predicted.
     """
     return stats.gmean([
-        _rank(item, recommendation)
+        rank(item, recommendation)
         for item in relevant_items
     ])
 

--- a/rexmex/metrics/ranking.py
+++ b/rexmex/metrics/ranking.py
@@ -1,11 +1,14 @@
 from math import log2
-from typing import List
+from typing import List, Sequence
 import numpy as np
 from scipy import stats
 from sklearn.metrics.pairwise import cosine_similarity
 import itertools
 from sklearn.metrics import dcg_score, ndcg_score
+from typing import Variable
 
+
+X = Variable(X)
 
 def reciprocal_rank(relevant_item: any, recommendation: List) -> float:
     """
@@ -44,13 +47,13 @@ def mean_reciprocal_rank(relevant_items: List, recommendation: List):
     return np.mean(reciprocal_ranks)
 
 
-def rank(relevant_item: any, recommendation: List) -> float:
+def rank(relevant_item: X, recommendation: Sequence[X]) -> float:
     """
     Calculate the rank of an item in a ranked list of items.
 
     Args:
-        relevant_item (any): a target item in the predicted list of items.
-        recommendation (array-like): An N x 1 predicted of items.
+        relevant_item: a target item in the predicted list of items.
+        recommendation: An N x 1 sequence of predicted items.
     Returns:
         rank (float): The rank of the item.
     """
@@ -60,13 +63,13 @@ def rank(relevant_item: any, recommendation: List) -> float:
             return i + 1.0
 
 
-def mean_rank(relevant_items: List, recommendation: List) -> float:
+def mean_rank(relevant_items: Sequence[X], recommendation: Sequence[X]) -> float:
     """
     Calculate the arithmetic mean rank (MR) of items in a ranked list.
 
     Args:
-        relevant_items (array-like): An N x 1 array of relevant items.
-        predicted (array-like):  An N x 1 array of ordered items.
+        relevant_items: An N x 1 sequence of relevant items.
+        predicted:  An N x 1 sequence of ordered items.
     Returns:
         MR (float): The mean rank of the relevant items in a predicted.
     """
@@ -76,13 +79,13 @@ def mean_rank(relevant_items: List, recommendation: List) -> float:
     ])
 
 
-def gmean_rank(relevant_items: List, recommendation: List) -> float:
+def gmean_rank(relevant_items: Sequence[X], recommendation: Sequence[X]) -> float:
     """
     Calculate the geometric mean rank (GMR) of items in a ranked list.
 
     Args:
-        relevant_items (array-like): An N x 1 array of relevant items.
-        predicted (array-like):  An N x 1 array of ordered items.
+        relevant_items: An N x 1 sequence of relevant items.
+        predicted:  An N x 1 sequence of ordered items.
     Returns:
         GMR (float): The mean reciprocal rank of the relevant items in a predicted.
     """

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -50,9 +50,12 @@ from rexmex.metrics.ranking import (
     kendall_tau,
     mean_average_precision_at_k,
     mean_average_recall_at_k,
+    mean_rank,
+    gmean_rank,
     mean_reciprocal_rank,
     novelty,
     personalization,
+    rank,
     reciprocal_rank,
     spearmans_rho,
 )
@@ -176,6 +179,36 @@ class TestRankingMetrics(unittest.TestCase):
 
         mrr = mean_reciprocal_rank(actual, rec)
         self.assertAlmostEqual(expected_mrr, mrr, 3)
+
+    def test_rank(self):
+        """Test the rank function."""
+        assert rank(1, self.ranking) == 1
+        assert rank(2, self.ranking) == 6
+        assert rank(3, self.ranking) == 3
+
+    def test_mean_rank(self):
+        actual = ["a", "b", "c"]
+        rec = ["b", "c", "a"]
+
+        a_r = 3
+        b_r = 1
+        c_r = 2
+        expected_mr = (a_r + b_r + c_r) / 3
+
+        mr = mean_rank(actual, rec)
+        self.assertAlmostEqual(expected_mr, mr, 3)
+
+    def test_gmean_rank(self):
+        actual = ["a", "b", "c"]
+        rec = ["b", "c", "a"]
+
+        a_rr = 3
+        b_rr = 1
+        c_rr = 2
+        expected_gmr = (a_rr * b_rr * c_rr) ** (1/ 3)
+
+        gmr = gmean_rank(actual, rec)
+        self.assertAlmostEqual(expected_gmr, gmr, 3)
 
     def test_average_percision_at_k(self):
 


### PR DESCRIPTION
# Summary
 
This PR follows the style of the implementation of the mean reciprocal rank to add an implementation of the rank helper function, the mean rank, and the geometric mean rank (originally described [here](https://cthoyt.com/2021/04/19/pythagorean-mean-ranks.html)).


- [x] Code passes all tests
- [x] Unit tests provided for these changes
- [x] Documentation and docstrings added for these changes

## Changes 

* Implement `rank()` helper function similar to `reciprocal_rank()` helper function
* Implement `mean_rank()` function, corresponding to the commonly used mean rank (MR) metric in KGEM evaluation
* Implement the `gmean_rank()` function, corresponding to recently introduced geometric mean rank (GMR) metric useful for KGEM evaluation

## Questions

- It would be possible to re-implement the `reciprocal_rank()` function simply with `return 1.0 / rank(relevant_item, recommendation)`. I'm not sure if there was a specific reason why MRR was implemented but not MR, but the logic is heavily related so it might even be more instructive to have one implemented in terms of the other