### PR TITLE
Ensure consistent ordering of imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+include_trailing_comma = true
+reverse_relative = true

--- a/rexmex/__init__.py
+++ b/rexmex/__init__.py
@@ -1,4 +1,4 @@
-from rexmex import scorecard, dataset, metricset, utils
-from rexmex.metrics import classification, ranking, rating, coverage
+from rexmex import dataset, metricset, scorecard, utils
+from rexmex.metrics import classification, coverage, ranking, rating
 
 all = ["scorecard", "dataset", "rexmex.metrics.*", "metricset", "utils"]

--- a/rexmex/dataset.py
+++ b/rexmex/dataset.py
@@ -1,4 +1,5 @@
 import io
+
 import pandas as pd
 from six.moves import urllib
 

--- a/rexmex/metrics/__init__.py
+++ b/rexmex/metrics/__init__.py
@@ -1,4 +1,4 @@
 from .classification import *
 from .coverage import *
-from .rating import *
 from .ranking import *
+from .rating import *

--- a/rexmex/metrics/ranking.py
+++ b/rexmex/metrics/ranking.py
@@ -1,11 +1,11 @@
+import itertools
 from math import log2
-from typing import List, Sequence
+from typing import List, Sequence, TypeVar
+
 import numpy as np
 from scipy import stats
-from sklearn.metrics.pairwise import cosine_similarity
-import itertools
 from sklearn.metrics import dcg_score, ndcg_score
-from typing import TypeVar
+from sklearn.metrics.pairwise import cosine_similarity
 
 X = TypeVar("X")
 

--- a/rexmex/metrics/rating.py
+++ b/rexmex/metrics/rating.py
@@ -1,6 +1,6 @@
 import numpy as np
-import sklearn.metrics
 import scipy.stats.stats
+import sklearn.metrics
 
 
 def mean_squared_error(y_true: np.array, y_score: np.array) -> float:

--- a/rexmex/metricset.py
+++ b/rexmex/metricset.py
@@ -1,33 +1,28 @@
 from typing import List, Tuple
 
-from rexmex.utils import binarize, normalize
-
-from rexmex.metrics.classification import roc_auc_score
-from rexmex.metrics.classification import accuracy_score, balanced_accuracy_score
 from rexmex.metrics.classification import (
-    pr_auc_score,
-    specificity,
-    fowlkes_mallows_index,
-)
-from rexmex.metrics.classification import (
+    accuracy_score,
+    average_precision_score,
+    balanced_accuracy_score,
     f1_score,
+    fowlkes_mallows_index,
+    matthews_correlation_coefficient,
+    pr_auc_score,
     precision_score,
     recall_score,
-    average_precision_score,
-    matthews_correlation_coefficient,
+    roc_auc_score,
+    specificity,
 )
-
-from rexmex.metrics.rating import pearson_correlation_coefficient
 from rexmex.metrics.rating import (
     mean_absolute_error,
-    mean_squared_error,
     mean_absolute_percentage_error,
+    mean_squared_error,
+    pearson_correlation_coefficient,
     r2_score,
-)
-from rexmex.metrics.rating import (
-    symmetric_mean_absolute_percentage_error,
     root_mean_squared_error,
+    symmetric_mean_absolute_percentage_error,
 )
+from rexmex.utils import binarize, normalize
 
 
 class MetricSet(dict):

--- a/rexmex/scorecard.py
+++ b/rexmex/scorecard.py
@@ -1,7 +1,9 @@
+from typing import List
+
 import numpy as np
 import pandas as pd
+
 import rexmex.metricset
-from typing import List
 
 
 class ScoreCard(object):

--- a/rexmex/utils.py
+++ b/rexmex/utils.py
@@ -1,5 +1,6 @@
-import numpy as np
 from functools import wraps
+
+import numpy as np
 
 
 def binarize(metric):

--- a/tests/integration/test_aggregation.py
+++ b/tests/integration/test_aggregation.py
@@ -1,9 +1,10 @@
-import pytest
 import unittest
 
-from rexmex.scorecard import ScoreCard
+import pytest
+
 from rexmex.dataset import DatasetReader
 from rexmex.metricset import ClassificationMetricSet, RatingMetricSet
+from rexmex.scorecard import ScoreCard
 
 
 class TestMetricAggregation(unittest.TestCase):

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -1,5 +1,6 @@
-import pytest
 import unittest
+
+import pytest
 
 from rexmex.dataset import DatasetReader
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,65 +1,61 @@
-import pytest
 import unittest
+
 import numpy as np
-
-from rexmex.metrics.classification import precision_score, recall_score
-
-from rexmex.metrics.classification import condition_positive, condition_negative
-from rexmex.metrics.classification import (
-    true_positive,
-    true_negative,
-    false_positive,
-    false_negative,
-)
-from rexmex.metrics.classification import specificity, selectivity, true_negative_rate
-
-from rexmex.metrics.classification import sensitivity, hit_rate, true_positive_rate
+import pytest
 
 from rexmex.metrics.classification import (
-    positive_predictive_value,
-    negative_predictive_value,
-)
-from rexmex.metrics.classification import miss_rate, false_negative_rate
-from rexmex.metrics.classification import fall_out, false_positive_rate
-from rexmex.metrics.classification import false_discovery_rate, false_omission_rate
-
-from rexmex.metrics.classification import (
-    positive_likelihood_ratio,
-    negative_likelihood_ratio,
-)
-from rexmex.metrics.classification import (
-    prevalence_threshold,
-    threat_score,
+    condition_negative,
+    condition_positive,
     critical_success_index,
-)
-
-from rexmex.metrics.classification import (
+    diagnostic_odds_ratio,
+    fall_out,
+    false_discovery_rate,
+    false_negative,
+    false_negative_rate,
+    false_omission_rate,
+    false_positive,
+    false_positive_rate,
     fowlkes_mallows_index,
+    hit_rate,
     informedness,
     markedness,
-    diagnostic_odds_ratio,
+    miss_rate,
+    negative_likelihood_ratio,
+    negative_predictive_value,
+    positive_likelihood_ratio,
+    positive_predictive_value,
+    precision_score,
+    prevalence_threshold,
+    recall_score,
+    selectivity,
+    sensitivity,
+    specificity,
+    threat_score,
+    true_negative,
+    true_negative_rate,
+    true_positive,
+    true_positive_rate,
 )
 from rexmex.metrics.ranking import (
-    discounted_cumulative_gain,
-    normalized_discounted_cumulative_gain,
-    normalized_distance_based_performance_measure,
     average_precision_at_k,
     average_recall_at_k,
+    discounted_cumulative_gain,
+    gmean_rank,
     hits_at_k,
     intra_list_similarity,
     kendall_tau,
     mean_average_precision_at_k,
     mean_average_recall_at_k,
     mean_rank,
-    gmean_rank,
     mean_reciprocal_rank,
+    normalized_discounted_cumulative_gain,
+    normalized_distance_based_performance_measure,
     novelty,
     personalization,
     rank,
     reciprocal_rank,
     spearmans_rho,
 )
-
 from rexmex.metrics.rating import (
     root_mean_squared_error,
     symmetric_mean_absolute_percentage_error,

--- a/tests/unit/test_metricset.py
+++ b/tests/unit/test_metricset.py
@@ -1,16 +1,17 @@
 import sys
-import pytest
 import unittest
-import pandas as pd
 from io import StringIO
 
+import pandas as pd
+import pytest
 from sklearn.metrics import accuracy_score, balanced_accuracy_score
+
 from rexmex.metricset import (
-    MetricSet,
     ClassificationMetricSet,
-    RatingMetricSet,
-    RankingMetricSet,
     CoverageMetricSet,
+    MetricSet,
+    RankingMetricSet,
+    RatingMetricSet,
 )
 
 

--- a/tests/unit/test_scorecard.py
+++ b/tests/unit/test_scorecard.py
@@ -1,7 +1,8 @@
 import sys
-import pytest
 import unittest
 from io import StringIO
+
+import pytest
 
 from rexmex.metricset import ClassificationMetricSet
 from rexmex.scorecard import ScoreCard

--- a/tox.ini
+++ b/tox.ini
@@ -11,14 +11,17 @@ envlist =
 [testenv:lint]
 deps =
     black
+    isort
 skip_install = true
 commands =
     black rexmex/ tests/ setup.py
+    isort rexmex/ tests/ setup.py
 description = Run linters.
 
 [testenv:flake8]
 deps =
     flake8
     flake8-black
+    flake8-isort
 commands =
-    flake8 --select BLK120 rexmex/ tests/ setup.py
+    flake8 --select BLK120,I001 rexmex/ tests/ setup.py


### PR DESCRIPTION
# Summary
 
This PR adds configuration to the `lint` environment in the `tox.ini` configuration to run [`isort`](https://github.com/PyCQA/isort), a tool for automatically sorting your imports in a consistent and deterministic way. It also adds some configuration to make it play nice with the `black` code formatter and an entry into the `flake8` configuration so CI checks that isort was applied.

- [x] Code passes all tests
- [x] Unit tests provided for these changes
- [x] Documentation and docstrings added for these changes

## Changes 

1. Add `isort` to lint environment
2. Add `isort` configuration in `pyproject.toml`
3. Apply `isort`