### PR TITLE
Add static type checking with MyPy

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,6 +33,9 @@ jobs:
       - name: Run code quality tests
         run: |
           tox -e flake8
+      - name: Run type checking
+        run: |
+          tox -e mypy
       - name: Install main package
         run: |
           pip install -e .[test]

--- a/rexmex/metrics/ranking.py
+++ b/rexmex/metrics/ranking.py
@@ -15,8 +15,8 @@ def reciprocal_rank(relevant_item: X, recommendation: Sequence[X]) -> float:
     Calculate the reciprocal rank (RR) of an item in a ranked list of items.
 
     Args:
-        relevant_item (any): a target item in the predicted list of items.
-        recommendation (array-like): An N x 1 predicted of items.
+        relevant_item: a target item in the predicted list of items.
+        recommendation: An N x 1 sequence of predicted items.
     Returns:
         RR (float): The reciprocal rank of the item.
     """

--- a/rexmex/metrics/ranking.py
+++ b/rexmex/metrics/ranking.py
@@ -10,7 +10,7 @@ from typing import TypeVar
 X = TypeVar("X")
 
 
-def reciprocal_rank(relevant_item: any, recommendation: List) -> float:
+def reciprocal_rank(relevant_item: X, recommendation: Sequence[X]) -> float:
     """
     Calculate the reciprocal rank (RR) of an item in a ranked list of items.
 
@@ -26,6 +26,7 @@ def reciprocal_rank(relevant_item: any, recommendation: List) -> float:
     for i, item in enumerate(recommendation):
         if item == relevant_item:
             return 1.0 / (i + 1.0)
+    raise ValueError
 
 
 def mean_reciprocal_rank(relevant_items: List, recommendation: List):
@@ -61,6 +62,7 @@ def rank(relevant_item: X, recommendation: Sequence[X]) -> float:
     for i, item in enumerate(recommendation):
         if item == relevant_item:
             return i + 1.0
+    raise ValueError
 
 
 def mean_rank(relevant_items: Sequence[X], recommendation: Sequence[X]) -> float:
@@ -363,7 +365,7 @@ def novelty(recommendations: List[list], item_popularities: dict, num_users: int
     epsilon = 1e-10
     all_self_information = []
     for recommendations in recommendations:
-        self_information_sum = 0
+        self_information_sum = 0.0
         for i in range(k):
             item = recommendations[i]
             item_pop = item_popularities[item]

--- a/rexmex/metrics/ranking.py
+++ b/rexmex/metrics/ranking.py
@@ -20,13 +20,10 @@ def reciprocal_rank(relevant_item: X, recommendation: Sequence[X]) -> float:
     Returns:
         RR (float): The reciprocal rank of the item.
     """
-
-    assert relevant_item in recommendation
-
     for i, item in enumerate(recommendation):
         if item == relevant_item:
             return 1.0 / (i + 1.0)
-    raise ValueError
+    raise ValueError("relevant item did not appear in recommendation")
 
 
 def mean_reciprocal_rank(relevant_items: List, recommendation: List):
@@ -58,11 +55,10 @@ def rank(relevant_item: X, recommendation: Sequence[X]) -> float:
     Returns:
         : The rank of the item.
     """
-    assert relevant_item in recommendation
     for i, item in enumerate(recommendation):
         if item == relevant_item:
             return i + 1.0
-    raise ValueError
+    raise ValueError("relevant item did not appear in recommendation")
 
 
 def mean_rank(relevant_items: Sequence[X], recommendation: Sequence[X]) -> float:

--- a/rexmex/metricset.py
+++ b/rexmex/metricset.py
@@ -45,6 +45,8 @@ class MetricSet(dict):
         Returns:
             self: The metric set after the metrics were filtered out.
         """
+        if not filter:
+            return self
         for name in list(self.keys()):
             if name not in filter:
                 del self[name]

--- a/rexmex/metricset.py
+++ b/rexmex/metricset.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import Collection, List, Tuple
 
 from rexmex.metrics.classification import (
     accuracy_score,
@@ -31,17 +31,15 @@ class MetricSet(dict):
      name keys and evaluation metric function values.
     """
 
-    def filter_metrics(self, filter: List[str] = None):
+    def filter_metrics(self, filter: Collection[str]):
         """
         A method to keep a list of metrics.
 
         Args:
-            filter (str): A list of metric names to keep.
+            filter: A list of metric names to keep.
         Returns:
             self: The metric set after the metrics were filtered out.
         """
-        if not filter:
-            return self
         for name in list(self.keys()):
             if name not in filter:
                 del self[name]

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -164,6 +164,9 @@ class TestRankingMetrics(unittest.TestCase):
         self.ranking = np.array([1, 7, 3, 4, 5, 2, 10, 8, 9, 6])
 
     def test_reciprocal_rank(self):
+        with self.assertRaises(ValueError):
+            reciprocal_rank(-1, self.ranking)
+
         assert reciprocal_rank(1, self.ranking) == 1
         assert reciprocal_rank(2, self.ranking) == 1 / 6
         assert reciprocal_rank(3, self.ranking) == 1 / 3
@@ -182,6 +185,9 @@ class TestRankingMetrics(unittest.TestCase):
 
     def test_rank(self):
         """Test the rank function."""
+        with self.assertRaises(ValueError):
+            rank(-1, self.ranking)
+
         assert rank(1, self.ranking) == 1
         assert rank(2, self.ranking) == 6
         assert rank(3, self.ranking) == 3

--- a/tests/unit/test_metricset.py
+++ b/tests/unit/test_metricset.py
@@ -23,6 +23,9 @@ class TestMetricSet(unittest.TestCase):
 
     def test_metric_filter(self):
         metric_set = ClassificationMetricSet()
+        # Test that filtering with no argument doesn't change anything
+        n_metrics = len(metric_set)
+        assert len(metric_set.filter_metrics()) == n_metrics
         metric_set.filter_metrics(["roc_auc", "pr_auc"])
         assert len(metric_set) == 2
         metric_set = ClassificationMetricSet()

--- a/tests/unit/test_metricset.py
+++ b/tests/unit/test_metricset.py
@@ -24,9 +24,6 @@ class TestMetricSet(unittest.TestCase):
 
     def test_metric_filter(self):
         metric_set = ClassificationMetricSet()
-        # Test that filtering with no argument doesn't change anything
-        n_metrics = len(metric_set)
-        assert len(metric_set.filter_metrics()) == n_metrics
         metric_set.filter_metrics(["roc_auc", "pr_auc"])
         assert len(metric_set) == 2
         metric_set = ClassificationMetricSet()

--- a/tox.ini
+++ b/tox.ini
@@ -22,3 +22,11 @@ deps =
     flake8-black
 commands =
     flake8 --select BLK120 rexmex/ tests/ setup.py
+
+[testenv:mypy]
+deps = mypy
+skip_install = true
+commands =
+    mypy --install-types --non-interactive --ignore-missing-imports rexmex/ tests/
+description = Run the mypy tool to check static typing on the project.
+


### PR DESCRIPTION
# Summary
 
This PR adds optional static type checking using [`mypy`](http://mypy-lang.org/), which uses the type hints to check for errors that don't show up from unit tests.
 
- [x] Code passes all tests
- [x] Unit tests provided for these changes
- [x] Documentation and docstrings added for these changes

## Changes 

1. Add `mypy` environment to `tox.ini`
2. Add call to mypy via tox in the GHA configuration for CI
3. Make a few improvements to code based on suggestions from type checker
4. Add additional tests