### PR TITLE
basic coverage statistic

### DIFF
--- a/rexmex/metrics/coverage.py
+++ b/rexmex/metrics/coverage.py
@@ -1,0 +1,31 @@
+from typing import List
+from collections import Counter
+
+
+def item_coverage(relevant_items: List, recommendations: List[List]) -> float:
+    """
+    Calculates the coverage value for items in relevant_items given the collection of recommendations.
+    This is defined as the fraction of items that got recommended at least once, divided by all possible items.
+
+    Example:
+
+        item_coverage([1, 2, 3, 4, 5],
+              [[1, 2, 3], [2, 3, 4], [1, 2, 4]])
+
+        has 80% coverage. One element out of five was never recommended.
+
+    Args:
+        relevant_items (List): items that could be recommended
+        recommendations (List[List]): collection of recommendations, each sublist is a separate recommendation,
+        e.g. for one user
+
+    Returns:
+        coverage (float): Single coverage statistic for the given set of recommendations.
+
+    """
+    if len(relevant_items) == 0:
+        raise ValueError("relevant_items cannot be empty!")
+
+    rec_item_counter = Counter([x for y in recommendations for x in y])
+    total_rec_per_item = [rec_item_counter.get(i, 0) for i in relevant_items]
+    return sum([x != 0 for x in total_rec_per_item]) / len(total_rec_per_item)

--- a/rexmex/metrics/coverage.py
+++ b/rexmex/metrics/coverage.py
@@ -1,5 +1,5 @@
-from typing import List
 from collections import Counter
+from typing import List
 
 
 def item_coverage(relevant_items: List, recommendations: List[List]) -> float:

--- a/rexmex/metrics/ranking.py
+++ b/rexmex/metrics/ranking.py
@@ -71,10 +71,7 @@ def mean_rank(relevant_items: Sequence[X], recommendation: Sequence[X]) -> float
     Returns:
         : The mean rank of the relevant items in a predicted.
     """
-    return np.mean([
-        rank(item, recommendation)
-        for item in relevant_items
-    ])
+    return np.mean([rank(item, recommendation) for item in relevant_items])
 
 
 def gmean_rank(relevant_items: Sequence[X], recommendation: Sequence[X]) -> float:
@@ -87,10 +84,7 @@ def gmean_rank(relevant_items: Sequence[X], recommendation: Sequence[X]) -> floa
     Returns:
         : The mean reciprocal rank of the relevant items in a predicted.
     """
-    return stats.gmean([
-        rank(item, recommendation)
-        for item in relevant_items
-    ])
+    return stats.gmean([rank(item, recommendation) for item in relevant_items])
 
 
 def average_precision_at_k(relevant_items: np.array, recommendation: np.array, k=10):

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -3,8 +3,6 @@ import unittest
 import numpy as np
 import pytest
 
-from rexmex.metrics.coverage import item_coverage
-
 from rexmex.metrics.classification import (
     condition_negative,
     condition_positive,
@@ -38,6 +36,7 @@ from rexmex.metrics.classification import (
     true_positive,
     true_positive_rate,
 )
+from rexmex.metrics.coverage import item_coverage
 from rexmex.metrics.ranking import (
     average_precision_at_k,
     average_recall_at_k,

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -61,6 +61,8 @@ from rexmex.metrics.rating import (
     symmetric_mean_absolute_percentage_error,
 )
 
+from rexmex.metrics.coverage import item_coverage
+
 
 class TestClassificationMetrics(unittest.TestCase):
     """
@@ -207,7 +209,7 @@ class TestRankingMetrics(unittest.TestCase):
         a_rr = 3
         b_rr = 1
         c_rr = 2
-        expected_gmr = (a_rr * b_rr * c_rr) ** (1/ 3)
+        expected_gmr = (a_rr * b_rr * c_rr) ** (1 / 3)
 
         gmr = gmean_rank(actual, rec)
         self.assertAlmostEqual(expected_gmr, gmr, 3)
@@ -388,3 +390,9 @@ class TestRankingMetrics(unittest.TestCase):
         scores = np.asarray([[0.1, 0.2, 0.3, 4, 70]])
         ndcg = normalized_discounted_cumulative_gain(true_relevance, scores)
         self.assertAlmostEqual(ndcg, 0.6956, 2)
+
+    def test_item_coverage(self):
+        assert item_coverage([1, 2, 3, 4, 5], [[1, 2, 3], [2, 3, 4], [1, 2, 4]]) == 0.8
+        assert item_coverage([1, 2, 3, 4], [[1, 2, 3], [2, 3, 4], [1, 2, 4]]) == 1.0
+        assert item_coverage([999], [[1, 2, 3], [2, 3, 4], [1, 2, 4]]) == 0.0
+        assert item_coverage(["a", "b", "c", "d"], [["a", "b"], ["c"]]) == 0.75

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -3,6 +3,8 @@ import unittest
 import numpy as np
 import pytest
 
+from rexmex.metrics.coverage import item_coverage
+
 from rexmex.metrics.classification import (
     condition_negative,
     condition_positive,
@@ -60,8 +62,6 @@ from rexmex.metrics.rating import (
     root_mean_squared_error,
     symmetric_mean_absolute_percentage_error,
 )
-
-from rexmex.metrics.coverage import item_coverage
 
 
 class TestClassificationMetrics(unittest.TestCase):


### PR DESCRIPTION
Basic coverage stat showing what fraction of objects ever got recommended from a list of recommendations. E.g. 0.8 means that 1 out of 5 possible objects never got recommended.

The naming might need refactoring soon as we agree on the specific names and how they relate to commonly used names.

- [X] Code passes all tests
- [X] Unit tests provided for these changes
- [X] Documentation and docstrings added for these changes
