### PR TITLE
Increase flake8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[tool.black]
+line-length = 120
+target-version = ["py37", "py38", "py39"]
+
 [tool.isort]
 profile = "black"
 multi_line_output = 3

--- a/rexmex/__init__.py
+++ b/rexmex/__init__.py
@@ -1,4 +1,2 @@
-from rexmex import dataset, metricset, scorecard, utils
-from rexmex.metrics import classification, coverage, ranking, rating
-
-all = ["scorecard", "dataset", "rexmex.metrics.*", "metricset", "utils"]
+from rexmex import dataset, metricset, scorecard, utils  # noqa:F401
+from rexmex.metrics import classification, coverage, ranking, rating  # noqa:F401

--- a/rexmex/metrics/__init__.py
+++ b/rexmex/metrics/__init__.py
@@ -1,4 +1,4 @@
-from .classification import *
-from .coverage import *
-from .ranking import *
-from .rating import *
+from .classification import *  # noqa:F401,F403
+from .coverage import *  # noqa:F401,F403
+from .ranking import *  # noqa:F401,F403
+from .rating import *  # noqa:F401,F403

--- a/rexmex/metrics/ranking.py
+++ b/rexmex/metrics/ranking.py
@@ -71,10 +71,7 @@ def mean_rank(relevant_items: Sequence[X], recommendation: Sequence[X]) -> float
     Returns:
         : The mean rank of the relevant items in a predicted.
     """
-    return np.mean([
-        rank(item, recommendation)
-        for item in relevant_items
-    ])
+    return np.mean([rank(item, recommendation) for item in relevant_items])
 
 
 def gmean_rank(relevant_items: Sequence[X], recommendation: Sequence[X]) -> float:
@@ -87,10 +84,7 @@ def gmean_rank(relevant_items: Sequence[X], recommendation: Sequence[X]) -> floa
     Returns:
         : The mean reciprocal rank of the relevant items in a predicted.
     """
-    return stats.gmean([
-        rank(item, recommendation)
-        for item in relevant_items
-    ])
+    return stats.gmean([rank(item, recommendation) for item in relevant_items])
 
 
 def average_precision_at_k(relevant_items: np.array, recommendation: np.array, k=10):

--- a/tests/integration/test_aggregation.py
+++ b/tests/integration/test_aggregation.py
@@ -1,7 +1,5 @@
 import unittest
 
-import pytest
-
 from rexmex.dataset import DatasetReader
 from rexmex.metricset import ClassificationMetricSet, RatingMetricSet
 from rexmex.scorecard import ScoreCard
@@ -19,14 +17,10 @@ class TestMetricAggregation(unittest.TestCase):
         performance_metrics = score_card.generate_report(self.scores)
         assert performance_metrics.shape == (1, 11)
 
-        performance_metrics = score_card.generate_report(
-            self.scores, grouping=["source_group"]
-        )
+        performance_metrics = score_card.generate_report(self.scores, grouping=["source_group"])
         assert performance_metrics.shape == (5, 11)
 
-        performance_metrics = score_card.generate_report(
-            self.scores, grouping=["source_group", "target_group"]
-        )
+        performance_metrics = score_card.generate_report(self.scores, grouping=["source_group", "target_group"])
         assert performance_metrics.shape == (20, 11)
 
     def test_regression(self):
@@ -37,14 +31,10 @@ class TestMetricAggregation(unittest.TestCase):
         performance_metrics = score_card.generate_report(self.scores)
         assert performance_metrics.shape == (1, 7)
 
-        performance_metrics = score_card.generate_report(
-            self.scores, grouping=["source_group"]
-        )
+        performance_metrics = score_card.generate_report(self.scores, grouping=["source_group"])
         assert performance_metrics.shape == (5, 7)
 
-        performance_metrics = score_card.generate_report(
-            self.scores, grouping=["source_group", "target_group"]
-        )
+        performance_metrics = score_card.generate_report(self.scores, grouping=["source_group", "target_group"])
         assert performance_metrics.shape == (20, 7)
 
     def test_addition(self):
@@ -54,12 +44,8 @@ class TestMetricAggregation(unittest.TestCase):
         performance_metrics = score_card.generate_report(self.scores)
         assert performance_metrics.shape == (1, 18)
 
-        performance_metrics = score_card.generate_report(
-            self.scores, grouping=["source_group"]
-        )
+        performance_metrics = score_card.generate_report(self.scores, grouping=["source_group"])
         assert performance_metrics.shape == (5, 18)
 
-        performance_metrics = score_card.generate_report(
-            self.scores, grouping=["source_group", "target_group"]
-        )
+        performance_metrics = score_card.generate_report(self.scores, grouping=["source_group", "target_group"])
         assert performance_metrics.shape == (20, 18)

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -1,7 +1,5 @@
 import unittest
 
-import pytest
-
 from rexmex.dataset import DatasetReader
 
 
@@ -13,16 +11,11 @@ class TestErdosRenyiDataset(unittest.TestCase):
 
         assert dataset.shape[0] == 50378
         assert dataset.shape[1] == 6
-        assert (
-            set(
-                [
-                    "source_group",
-                    "target_group",
-                    "source_id",
-                    "target_id",
-                    "y_score",
-                    "y_true",
-                ]
-            ).issubset(dataset.columns)
-            == True
-        )
+        assert {
+            "source_group",
+            "target_group",
+            "source_id",
+            "target_id",
+            "y_score",
+            "y_true",
+        }.issubset(dataset.columns)

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,7 +1,6 @@
 import unittest
 
 import numpy as np
-import pytest
 
 from rexmex.metrics.classification import (
     condition_negative,
@@ -207,7 +206,7 @@ class TestRankingMetrics(unittest.TestCase):
         a_rr = 3
         b_rr = 1
         c_rr = 2
-        expected_gmr = (a_rr * b_rr * c_rr) ** (1/ 3)
+        expected_gmr = (a_rr * b_rr * c_rr) ** (1 / 3)
 
         gmr = gmean_rank(actual, rec)
         self.assertAlmostEqual(expected_gmr, gmr, 3)

--- a/tests/unit/test_metricset.py
+++ b/tests/unit/test_metricset.py
@@ -2,8 +2,6 @@ import sys
 import unittest
 from io import StringIO
 
-import pandas as pd
-import pytest
 from sklearn.metrics import accuracy_score, balanced_accuracy_score
 
 from rexmex.metricset import (

--- a/tests/unit/test_scorecard.py
+++ b/tests/unit/test_scorecard.py
@@ -2,8 +2,6 @@ import sys
 import unittest
 from io import StringIO
 
-import pytest
-
 from rexmex.metricset import ClassificationMetricSet
 from rexmex.scorecard import ScoreCard
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
     flake8-black
     flake8-isort
 commands =
-    flake8 --select BLK120,I001 rexmex/ tests/ setup.py
+    flake8 --max-line-length 120 rexmex/ tests/ setup.py
 
 [testenv:mypy]
 deps = mypy


### PR DESCRIPTION
# Summary
 
This PR adds more flake8 checks and better standardizes applying black with a line length of 120.
 
- [x] Code passes all tests
- [x] Unit tests provided for these changes
- [x] Documentation and docstrings added for these changes

## Changes 

- Add black configuration in pyproject.toml
- Enable all flake8 tests by removing the `--select BLK120,I001` flag
- Ensure tox's run of flake8 has the right line length with the `--max-line-length 120` flag
- Apply black (not sure why this wasn't being picked up before :/)
- Code cleanup (remove unused imports, fix literals, add noqa for some imports [for now])