### PR TITLE
Add binarize annotation

### DIFF
--- a/rexmex/metrics/classification.py
+++ b/rexmex/metrics/classification.py
@@ -96,6 +96,7 @@ def false_negative(y_true: np.array, y_score: np.array) -> float:
     higher_is_better=True,
     description="TN / (TN + FP)",
     link="https://en.wikipedia.org/wiki/Specificity_(tests)",
+    binarize=True,
 )
 def specificity(y_true: np.array, y_score: np.array) -> float:
     """
@@ -530,6 +531,7 @@ def critical_success_index(y_true: np.array, y_score: np.array) -> float:
     higher_is_better=True,
     description="√PPV x √TPR",
     link="https://en.wikipedia.org/wiki/Fowlkes%E2%80%93Mallows_index",
+    binarize=True,
 )
 def fowlkes_mallows_index(y_true: np.array, y_score: np.array) -> float:
     """
@@ -649,6 +651,7 @@ def roc_auc_score(y_true: np.array, y_score: np.array) -> float:
     higher_is_better=True,
     description="(TP + TN) / (TP + TN + FP + FN)",
     link="https://en.wikipedia.org/wiki/Accuracy",
+    binarize=True,
 )
 def accuracy_score(y_true: np.array, y_score: np.array) -> float:
     """
@@ -671,6 +674,7 @@ def accuracy_score(y_true: np.array, y_score: np.array) -> float:
     higher_is_better=True,
     description="An adjusted version of the accuracy for imbalanced datasets",
     link="https://scikit-learn.org/stable/modules/generated/sklearn.metrics.balanced_accuracy_score.html",
+    binarize=True,
 )
 def balanced_accuracy_score(y_true: np.array, y_score: np.array) -> float:
     """
@@ -693,6 +697,7 @@ def balanced_accuracy_score(y_true: np.array, y_score: np.array) -> float:
     higher_is_better=True,
     description="2TP / (2TP + FP + FN)",
     link="https://en.wikipedia.org/wiki/F1_score",
+    binarize=True,
 )
 def f1_score(y_true: np.array, y_score: np.array) -> float:
     """
@@ -715,6 +720,7 @@ def f1_score(y_true: np.array, y_score: np.array) -> float:
     higher_is_better=True,
     description="TP / (TP + FP)",
     link="https://en.wikipedia.org/wiki/Positive_predictive_value",
+    binarize=True,
 )
 def precision_score(y_true: np.array, y_score: np.array) -> float:
     """
@@ -737,6 +743,7 @@ def precision_score(y_true: np.array, y_score: np.array) -> float:
     higher_is_better=True,
     description="TP / (TP + FN)",
     link="https://en.wikipedia.org/wiki/Sensitivity_(test)",
+    binarize=True,
 )
 def recall_score(y_true: np.array, y_score: np.array) -> float:
     """
@@ -783,6 +790,7 @@ def average_precision_score(y_true: np.array, y_score: np.array) -> float:
     higher_is_better=True,
     description="A balanced measure applicable even with class imbalance",
     link="https://en.wikipedia.org/wiki/Phi_coefficient",
+    binarize=True,
 )
 def matthews_correlation_coefficient(y_true: np.array, y_score: np.array) -> float:
     """

--- a/rexmex/metrics/classification.py
+++ b/rexmex/metrics/classification.py
@@ -227,6 +227,7 @@ def true_positive_rate(y_true: np.array, y_score: np.array) -> float:
     higher_is_better=True,
     description="TP / (TP + FP)",
     link="https://en.wikipedia.org/wiki/Positive_predictive_value",
+    binarize=True,
 )
 def positive_predictive_value(y_true: np.array, y_score: np.array) -> float:
     """

--- a/rexmex/utils.py
+++ b/rexmex/utils.py
@@ -70,6 +70,7 @@ class Annotator:
         name: Optional[str] = None,
         lower_inclusive: bool = True,
         upper_inclusive: bool = True,
+        binarize: bool = False,
     ):
         """Annotate a classification function."""
 
@@ -82,6 +83,7 @@ class Annotator:
             func.higher_is_better = higher_is_better
             func.link = link
             func.description = description
+            func.binarize = binarize
             return func
 
         return _wrapper

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -95,6 +95,7 @@ class TestClassificationMetrics(unittest.TestCase):
                 self.assert_hasattr(func, "link", str)
                 self.assert_hasattr(func, "lower_inclusive", bool)
                 self.assert_hasattr(func, "upper_inclusive", bool)
+                self.assert_hasattr(func, "binarize", bool)
 
     def assert_hasattr(self, obj, name, cls):
         """Check a function is annotated."""

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -126,9 +126,10 @@ class TestClassificationMetrics(unittest.TestCase):
         assert hit_rate(self.y_true, self.y_score) == recall_score(self.y_true, self.y_score)
         assert true_positive_rate(self.y_true, self.y_score) == recall_score(self.y_true, self.y_score)
 
-    def test_positivie_predictive_value(self):
-        assert hasattr(precision_score, "lower")
+    def test_positive_predictive_value(self):
         assert precision_score.lower == 0.0
+        assert precision_score.upper == 1.0
+        assert not precision_score.binarize
 
         assert positive_predictive_value(self.y_true, self.y_score) == precision_score(self.y_true, self.y_score)
         assert positive_predictive_value(self.y_true, self.y_score) == 4 / 9


### PR DESCRIPTION
# Summary
 
Similarly to #35, this PR adds an additional annotation for functions that need to be binarized.
 
- [x] Code passes all tests
- [x] Unit tests provided for these changes
- [x] Documentation and docstrings added for these changes

## Changes 

- Add additional keyword argument `binarize` to `rexmex.utils.Annotator.annotate`. This has a default of `False`, since most functions do not need to be binarized.
- Annotate `binarize=True` on the functions that were binarized in the `rexmex.metricset.ClassificationMetricSet.__init__`