### PR TITLE
Improve testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,11 @@ $ pip install rexmex --upgrade
 
 **Running tests**
 
+Tests can be run with `tox` with the following:
+
 ```sh
-$ pytest ./tests/unit -cov rexmex/
-$ pytest ./tests/integration -cov rexmex/
+$ pip install tox
+$ tox -e py
 ```
 
 --------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ $ pytest ./tests/integration -cov rexmex/
 
 **Citation**
 
-If you use RexMex in a scientific publication, we would appreciate citations. Please see GitHubs built in citation tool.
+If you use RexMex in a scientific publication, we would appreciate citations. Please see GitHub's built-in citation tool.
 
 
 

--- a/README.md
+++ b/README.md
@@ -179,8 +179,10 @@ We are motivated to constantly make RexMex even better.
 RexMex can be installed with the following command after the repo is cloned.
 
 ```sh
-$ python setup.py install
+$ pip install .
 ```
+
+Use `-e/--editable` when developing.
 
 **Installation via pip**
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup_requires = ["pytest-runner"]
 
 tests_require = ["pytest", "pytest-cov"]
 
+extras_require = {"test": tests_require}
 
 keywords = [
     "recommender",
@@ -37,6 +38,7 @@ setup(
     install_requires=install_requires,
     setup_requires=setup_requires,
     tests_require=tests_require,
+    extras_require=extras_require,
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ install_requires = ["numpy", "sklearn", "pandas", "scipy", "scikit-learn"]
 setup_requires = ["pytest-runner"]
 
 
-tests_require = ["pytest", "pytest-cov", "mock", "unittest"]
+tests_require = ["pytest", "pytest-cov"]
 
 
 keywords = [

--- a/tests/integration/test_aggregation.py
+++ b/tests/integration/test_aggregation.py
@@ -15,13 +15,13 @@ class TestMetricAggregation(unittest.TestCase):
         score_card = ScoreCard(metric_set)
 
         performance_metrics = score_card.generate_report(self.scores)
-        assert performance_metrics.shape == (1, 11)
+        assert performance_metrics.shape == (1, len(metric_set))
 
         performance_metrics = score_card.generate_report(self.scores, grouping=["source_group"])
-        assert performance_metrics.shape == (5, 11)
+        assert performance_metrics.shape == (5, len(metric_set))
 
         performance_metrics = score_card.generate_report(self.scores, grouping=["source_group", "target_group"])
-        assert performance_metrics.shape == (20, 11)
+        assert performance_metrics.shape == (20, len(metric_set))
 
     def test_regression(self):
         metric_set = RatingMetricSet()
@@ -29,23 +29,23 @@ class TestMetricAggregation(unittest.TestCase):
         score_card = ScoreCard(metric_set)
 
         performance_metrics = score_card.generate_report(self.scores)
-        assert performance_metrics.shape == (1, 7)
+        assert performance_metrics.shape == (1, len(metric_set))
 
         performance_metrics = score_card.generate_report(self.scores, grouping=["source_group"])
-        assert performance_metrics.shape == (5, 7)
+        assert performance_metrics.shape == (5, len(metric_set))
 
         performance_metrics = score_card.generate_report(self.scores, grouping=["source_group", "target_group"])
-        assert performance_metrics.shape == (20, 7)
+        assert performance_metrics.shape == (20, len(metric_set))
 
     def test_addition(self):
         metric_set = RatingMetricSet() + ClassificationMetricSet()
         score_card = ScoreCard(metric_set)
 
         performance_metrics = score_card.generate_report(self.scores)
-        assert performance_metrics.shape == (1, 18)
+        assert performance_metrics.shape == (1, len(metric_set))
 
         performance_metrics = score_card.generate_report(self.scores, grouping=["source_group"])
-        assert performance_metrics.shape == (5, 18)
+        assert performance_metrics.shape == (5, len(metric_set))
 
         performance_metrics = score_card.generate_report(self.scores, grouping=["source_group", "target_group"])
-        assert performance_metrics.shape == (20, 18)
+        assert performance_metrics.shape == (20, len(metric_set))

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,13 @@ envlist =
     lint
     flake8
     mypy
+    py
+
+[testenv:py]
+commands =
+    pytest --cov rexmex
+extras =
+    test
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
# Summary
 
This PR improves the documentation of installation, testing, and makes the unit tests less rigid to future improvements
 
- [x] Code passes all tests
- [x] Unit tests provided for these changes
- [x] Documentation and docstrings added for these changes

## Changes 

- Since all commands from `python setup.py` have been deprecated, it doesn't make sense to use `python setup.py test` anymore. This is the only place (AFAIK) where `tests_require` is used. As an alternative, this can be installed as an extra (as is already in the GitHub Actions workflow) with `pip install .[test]` (20cf0f9)
- Modernize installation instructions from deprecated `python setup.py install` to `pip install .` (dfff1af)
- Fix typos in README (6b1abb5)
- Update local testing instructions to use `tox` because it's more simple and takes care of all installation of package _and_ testing requirements (as solved in previous bullet point) (4f0815a)
- Remove hard-coded counts in metric tests, which makes it possible to arbitrarily extend the metric set definitions without needing to change the test code (d16e7dd)
