### PR TITLE
Cleanup scorecard interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,7 @@ If you find *RexMex* useful in your research, please consider adding the followi
 The following example loads a synthetic dataset which has the mandatory `y_true` and `y_score` keys.  The dataset has binary labels and predictied probability scores. We read the dataset and define a defult `ClassificationMetric` instance for the evaluation of the predictions. Using this metric set we create a score card and get the predictive performance metrics.
 
 ```python
-from rexmex.scorecard import ScoreCard
-from rexmex.dataset import DatasetReader
-from rexmex.metricset import ClassificationMetricSet
+from rexmex import ClassificationMetricSet, DatasetReader, ScoreCard
 
 reader = DatasetReader()
 scores = reader.read_dataset()
@@ -55,9 +53,7 @@ report = score_card.get_performance_metrics(scores["y_true"], scores["y_score"])
 The following more advanced example loads the same synthetic dataset which has the `source_id`, `target_id`, `source_group` and `target group` keys besides the mandatory `y_true` and `y_score`.   Using the `source_group` key  we group the predictions and return a performance metric report.
 
 ```python
-from rexmex.scorecard import ScoreCard
-from rexmex.dataset import DatasetReader
-from rexmex.metricset import ClassificationMetricSet
+from rexmex import ClassificationMetricSet, DatasetReader, ScoreCard
 
 reader = DatasetReader()
 scores = reader.read_dataset()

--- a/rexmex/__init__.py
+++ b/rexmex/__init__.py
@@ -1,2 +1,11 @@
 from rexmex import dataset, metricset, scorecard, utils  # noqa:F401
+from rexmex.dataset import DatasetReader  # noqa:F401
 from rexmex.metrics import classification, coverage, ranking, rating  # noqa:F401
+from rexmex.metricset import (  # noqa:F401
+    ClassificationMetricSet,
+    CoverageMetricSet,
+    MetricSet,
+    RankingMetricSet,
+    RatingMetricSet,
+)
+from rexmex.scorecard import ScoreCard  # noqa:F401

--- a/rexmex/scorecard.py
+++ b/rexmex/scorecard.py
@@ -1,17 +1,23 @@
-from typing import List
+from typing import List, Mapping
 
 import numpy as np
 import pandas as pd
 
-import rexmex.metricset
+from rexmex.utils import Metric
+
+__all__ = [
+    "ScoreCard",
+]
 
 
-class ScoreCard(object):
+class ScoreCard:
     """
-    A score card can be used to aggregate metrics, plot those, and generate performance reports.
+    A scorecard can be used to aggregate metrics, plot those, and generate performance reports.
     """
 
-    def __init__(self, metric_set: rexmex.metricset.MetricSet):
+    metric_set: Mapping[str, Metric]
+
+    def __init__(self, metric_set: Mapping[str, Metric]):
         self.metric_set = metric_set
 
     def get_performance_metrics(self, y_true: np.array, y_score: np.array) -> pd.DataFrame:
@@ -25,8 +31,8 @@ class ScoreCard(object):
             performance_metrics (pd.DataFrame): The performance metrics calculated from the vectors.
         """
         performance_metrics = {name: [metric(y_true, y_score)] for name, metric in self.metric_set.items()}
-        performance_metrics = pd.DataFrame.from_dict(performance_metrics)
-        return performance_metrics
+        performance_metrics_df = pd.DataFrame.from_dict(performance_metrics)
+        return performance_metrics_df
 
     def generate_report(self, scores_to_evaluate: pd.DataFrame, grouping: List[str] = None) -> pd.DataFrame:
         """
@@ -64,9 +70,9 @@ class ScoreCard(object):
             training_set (pd.DataFrame): A dataframe of training data points.
             testing_set (pd.DataFrame): A dataframe of testing data points.
             validation_set (pd.DataFrame): A dataframe of validation data points.
-            columns (list): A list of column names used for cross referencing.
+            columns (list): A list of column names used for cross-referencing.
         Returns:
-            scores (pd.DataFrame): The scores for datapoints which are not in the reference sets.
+            scores (pd.DataFrame): The scores for data points which are not in the reference sets.
         """
         scores_columns = list(scores.columns.tolist())
         in_sample_examples = pd.concat([training_set, testing_set, validation_set])
@@ -78,7 +84,7 @@ class ScoreCard(object):
         """
         A representation of the ScoreCard object.
         """
-        return "ScoreCard()"
+        return f"ScoreCard(metric_set={self.metric_set!r})"
 
     def print_metrics(self):
         """

--- a/rexmex/utils.py
+++ b/rexmex/utils.py
@@ -1,13 +1,17 @@
 from functools import wraps
-from typing import Optional
+from typing import Callable, Optional
 
 import numpy as np
 
 __all__ = [
+    "Metric",
     "binarize",
     "normalize",
     "Annotator",
 ]
+
+#: A function that can be called on y_true, y_score and return a floating point result
+Metric = Callable[[np.array, np.array], float]
 
 
 def binarize(metric):

--- a/tests/unit/test_scorecard.py
+++ b/tests/unit/test_scorecard.py
@@ -17,7 +17,7 @@ class TestMetricSet(unittest.TestCase):
         self.score_card = ScoreCard(self.metric_set)
 
     def test_representation(self):
-        assert repr(self.score_card) == "ScoreCard()"
+        assert repr(self.score_card) == "ScoreCard(metric_set=ClassificationMetricSet())"
 
     def test_printing(self):
         self.score_card.metric_set.filter_metrics(["roc_auc", "pr_auc"])


### PR DESCRIPTION
# Summary
 
This PR cleans up the scorecard interface and simplifies importing high-level functionality.
 
- [x] Code passes all tests
- [x] Unit tests provided for these changes
- [x] Documentation and docstrings added for these changes

## Changes 

- Make main classes importable from the `rexmex` interface. Since this package is pretty light, this doesn't have a big performance tradeoff.
- Update ScoreCard clas
   - Use more general type annotation for `metric_set` since any arbitrary dict would work here
   - Remove old-style class definition (i.e., inheriting from `object`)
   - Typo fixes
   - Update `repr()` to show repr of `metric_set`. In general, `__repr__` should be defined so `eval(repr(x)) == x`