### PR TITLE
Annotate redundant functions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,6 +29,7 @@ jobs:
          pip install codecov
          pip install pytest
          pip install tox
+         python setup.py install
       - name: Run code quality tests
         run: |
           tox -e flake8
@@ -37,7 +38,7 @@ jobs:
           tox -e mypy
       - name: Install main package
         run: |
-          tox -e py
+          pip install -e .[test]
       - name: Run test-suite
         run: |
           python -m pytest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,7 +29,6 @@ jobs:
          pip install codecov
          pip install pytest
          pip install tox
-         python setup.py install
       - name: Run code quality tests
         run: |
           tox -e flake8
@@ -38,7 +37,7 @@ jobs:
           tox -e mypy
       - name: Install main package
         run: |
-          pip install -e .[test]
+          tox -e py
       - name: Run test-suite
         run: |
           python -m pytest

--- a/rexmex/metrics/classification.py
+++ b/rexmex/metrics/classification.py
@@ -149,7 +149,6 @@ def selectivity(y_true: np.array, y_score: np.array) -> float:
     higher_is_better=True,
     description="TP / (TP + FN)",
     link="https://en.wikipedia.org/wiki/Sensitivity_(test)",
-    binarize=True,
 )
 def true_positive_rate(y_true: np.array, y_score: np.array) -> float:
     """
@@ -197,7 +196,7 @@ def sensitivity(y_true: np.array, y_score: np.array) -> float:
     return tpr
 
 
-@classifications.duplicate(true_positive_rate, name="Recall")
+@classifications.duplicate(true_positive_rate, name="Recall", binarize=True)
 def recall_score(y_true: np.array, y_score: np.array) -> float:
     """
     Calculate the recall for a ground-truth prediction vector pair.
@@ -210,6 +209,11 @@ def recall_score(y_true: np.array, y_score: np.array) -> float:
         y_score (array-like):  An N x 1 array of predicted values.
     Returns:
         recall (float): The value of recall.
+
+    .. note::
+
+        It's surprising that the sklearn implementation of TPR needs
+        to be binarized but the rexmex implementation does not
     """
     recall = sklearn.metrics.recall_score(y_true, y_score)
     return recall

--- a/rexmex/metrics/classification.py
+++ b/rexmex/metrics/classification.py
@@ -96,8 +96,22 @@ def false_negative(y_true: np.array, y_score: np.array) -> float:
     higher_is_better=True,
     description="TN / (TN + FP)",
     link="https://en.wikipedia.org/wiki/Specificity_(tests)",
-    binarize=True,
 )
+def true_negative_rate(y_true: np.array, y_score: np.array) -> float:
+    """
+    Calculate the true negative rate (same as specificity and selectivity).
+
+    Args:
+        y_true (array-like): An N x 1 array of ground truth values.
+        y_score (array-like):  An N x 1 array of predicted values.
+    Returns:
+        tnr (float): The true negative rate.
+    """
+    tnr = specificity(y_true, y_score)
+    return tnr
+
+
+@classifications.duplicate(true_negative_rate)
 def specificity(y_true: np.array, y_score: np.array) -> float:
     """
     Calculate the specificity (same as selectivity and true negative rate).
@@ -114,13 +128,7 @@ def specificity(y_true: np.array, y_score: np.array) -> float:
     return tnr
 
 
-@classifications.annotate(
-    lower=0.0,
-    upper=1.0,
-    higher_is_better=True,
-    description="TN / (TN + FP)",
-    link="https://en.wikipedia.org/wiki/Specificity_(tests)",
-)
+@classifications.duplicate(true_negative_rate)
 def selectivity(y_true: np.array, y_score: np.array) -> float:
     """
     Calculate the selectivity (same as specificity and true negative rate).
@@ -133,71 +141,6 @@ def selectivity(y_true: np.array, y_score: np.array) -> float:
     """
     tnr = specificity(y_true, y_score)
     return tnr
-
-
-@classifications.annotate(
-    lower=0.0,
-    upper=1.0,
-    higher_is_better=True,
-    description="TN / (TN + FP)",
-    link="https://en.wikipedia.org/wiki/Specificity_(tests)",
-)
-def true_negative_rate(y_true: np.array, y_score: np.array) -> float:
-    """
-    Calculate the true negative rate (same as specificity and selectivity).
-
-    Args:
-        y_true (array-like): An N x 1 array of ground truth values.
-        y_score (array-like):  An N x 1 array of predicted values.
-    Returns:
-        tnr (float): The true negative rate.
-    """
-    tnr = specificity(y_true, y_score)
-    return tnr
-
-
-@classifications.annotate(
-    lower=0.0,
-    upper=1.0,
-    higher_is_better=True,
-    description="TP / (TP + FN)",
-    link="https://en.wikipedia.org/wiki/Sensitivity_(test)",
-)
-def sensitivity(y_true: np.array, y_score: np.array) -> float:
-    """
-    Calculate the sensitivity (same as recall, hit rate and true positive rate).
-
-    Args:
-        y_true (array-like): An N x 1 array of ground truth values.
-        y_score (array-like):  An N x 1 array of predicted values.
-    Returns:
-        tpr (float): The sensitivity score.
-    """
-    p = condition_positive(y_true)
-    tp = true_positive(y_true, y_score)
-    tpr = tp / p
-    return tpr
-
-
-@classifications.annotate(
-    lower=0.0,
-    upper=1.0,
-    higher_is_better=True,
-    description="TP / (TP + FN)",
-    link="https://en.wikipedia.org/wiki/Sensitivity_(test)",
-)
-def hit_rate(y_true: np.array, y_score: np.array) -> float:
-    """
-    Calculate the hit rate (same as recall, sensitivity and true positive rate).
-
-    Args:
-        y_true (array-like): An N x 1 array of ground truth values.
-        y_score (array-like):  An N x 1 array of predicted values.
-    Returns:
-        tpr (float): The hit rate.
-    """
-    tpr = sensitivity(y_true, y_score)
-    return tpr
 
 
 @classifications.annotate(
@@ -218,6 +161,38 @@ def true_positive_rate(y_true: np.array, y_score: np.array) -> float:
         tpr (float): The true positive rate.
     """
     tpr = sensitivity(y_true, y_score)
+    return tpr
+
+
+@classifications.duplicate(true_positive_rate)
+def hit_rate(y_true: np.array, y_score: np.array) -> float:
+    """
+    Calculate the hit rate (same as recall, sensitivity and true positive rate).
+
+    Args:
+        y_true (array-like): An N x 1 array of ground truth values.
+        y_score (array-like):  An N x 1 array of predicted values.
+    Returns:
+        tpr (float): The hit rate.
+    """
+    tpr = sensitivity(y_true, y_score)
+    return tpr
+
+
+@classifications.duplicate(true_positive_rate)
+def sensitivity(y_true: np.array, y_score: np.array) -> float:
+    """
+    Calculate the sensitivity (same as recall, hit rate and true positive rate).
+
+    Args:
+        y_true (array-like): An N x 1 array of ground truth values.
+        y_score (array-like):  An N x 1 array of predicted values.
+    Returns:
+        tpr (float): The sensitivity score.
+    """
+    p = condition_positive(y_true)
+    tp = true_positive(y_true, y_score)
+    tpr = tp / p
     return tpr
 
 
@@ -278,9 +253,24 @@ def negative_predictive_value(y_true: np.array, y_score: np.array) -> float:
     description="FN / (FN + TP)",
     link="https://en.wikipedia.org/wiki/Type_I_and_type_II_errors#False_positive_and_false_negative_rates",
 )
+def false_negative_rate(y_true: np.array, y_score: np.array) -> float:
+    """
+    Calculate the false negative rate (same as miss rate).
+
+    Args:
+        y_true (array-like): An N x 1 array of ground truth values.
+        y_score (array-like):  An N x 1 array of predicted values.
+    Returns:
+        fnr (float): The false negative rate value.
+    """
+    fnr = miss_rate(y_true, y_score)
+    return fnr
+
+
+@classifications.duplicate(false_negative_rate)
 def miss_rate(y_true: np.array, y_score: np.array) -> float:
     """
-    Calculate the miss rate (same as false negative rate).
+    Calculate the miss rate (duplicate of :func:`false_negative_rate`).
 
     Args:
         y_true (array-like): An N x 1 array of ground truth values.
@@ -298,54 +288,8 @@ def miss_rate(y_true: np.array, y_score: np.array) -> float:
     lower=0.0,
     upper=1.0,
     higher_is_better=False,
-    description="FN / (FN + TP)",
-    link="https://en.wikipedia.org/wiki/Type_I_and_type_II_errors#False_positive_and_false_negative_rates",
-    duplicate_of=miss_rate,
-)
-def false_negative_rate(y_true: np.array, y_score: np.array) -> float:
-    """
-    Calculate the false negative rate (same as miss rate).
-
-    Args:
-        y_true (array-like): An N x 1 array of ground truth values.
-        y_score (array-like):  An N x 1 array of predicted values.
-    Returns:
-        fnr (float): The false negative rate value.
-    """
-    fnr = miss_rate(y_true, y_score)
-    return fnr
-
-
-@classifications.annotate(
-    lower=0.0,
-    upper=1.0,
-    higher_is_better=False,
     description="FP / (FP + TN)",
     link="https://en.wikipedia.org/wiki/False_positive_rate",
-)
-def fall_out(y_true: np.array, y_score: np.array) -> float:
-    """
-    Calculate the fall out (same as false positive rate).
-
-    Args:
-        y_true (array-like): An N x 1 array of ground truth values.
-        y_score (array-like):  An N x 1 array of predicted values.
-    Returns:
-        fpr (float): The fall out value.
-    """
-    fp = false_positive(y_true, y_score)
-    n = condition_negative(y_true)
-    fpr = fp / n
-    return fpr
-
-
-@classifications.annotate(
-    lower=0.0,
-    upper=1.0,
-    higher_is_better=False,
-    description="FP / (FP + TN)",
-    link="https://en.wikipedia.org/wiki/False_positive_rate",
-    duplicate_of=fall_out,
 )
 def false_positive_rate(y_true: np.array, y_score: np.array) -> float:
     """
@@ -358,6 +302,23 @@ def false_positive_rate(y_true: np.array, y_score: np.array) -> float:
         fpr (float): The false positive rate value.
     """
     fpr = fall_out(y_true, y_score)
+    return fpr
+
+
+@classifications.duplicate(false_positive_rate)
+def fall_out(y_true: np.array, y_score: np.array) -> float:
+    """
+    Calculate the fall out (duplicate of :func:`false_positive_rate`).
+
+    Args:
+        y_true (array-like): An N x 1 array of ground truth values.
+        y_score (array-like):  An N x 1 array of predicted values.
+    Returns:
+        fpr (float): The fall out value.
+    """
+    fp = false_positive(y_true, y_score)
+    n = condition_negative(y_true)
+    fpr = fp / n
     return fpr
 
 
@@ -507,17 +468,10 @@ def threat_score(y_true: np.array, y_score: np.array) -> float:
     return ts
 
 
-@classifications.annotate(
-    lower=0.0,
-    upper=1.0,
-    higher_is_better=True,
-    description="TP / (TP + FN + FP)",
-    link="https://rexmex.readthedocs.io/en/latest/modules/root.html#rexmex.metrics.classification.threat_score",
-    duplicate_of=threat_score,
-)
+@classifications.duplicate(threat_score)
 def critical_success_index(y_true: np.array, y_score: np.array) -> float:
     """
-    Calculate the critical success index (same as the theat score).
+    Calculate the critical success index (duplicate of :func:`threat_score`).
 
     Args:
         y_true (array-like): An N x 1 array of ground truth values.
@@ -717,15 +671,9 @@ def f1_score(y_true: np.array, y_score: np.array) -> float:
     return f1
 
 
-@classifications.annotate(
+@classifications.duplicate(
+    positive_predictive_value,
     name="Precision",
-    lower=0.0,
-    upper=1.0,
-    higher_is_better=True,
-    description="TP / (TP + FP)",
-    link="https://en.wikipedia.org/wiki/Positive_predictive_value",
-    binarize=True,
-    duplicate_of=positive_predictive_value,
 )
 def precision_score(y_true: np.array, y_score: np.array) -> float:
     """
@@ -741,16 +689,7 @@ def precision_score(y_true: np.array, y_score: np.array) -> float:
     return precision
 
 
-@classifications.annotate(
-    name="Recall",
-    lower=0.0,
-    upper=1.0,
-    higher_is_better=True,
-    description="TP / (TP + FN)",
-    link="https://en.wikipedia.org/wiki/Sensitivity_(test)",
-    binarize=True,
-    duplicate_of=true_positive_rate,
-)
+@classifications.duplicate(true_positive_rate, name="Recall")
 def recall_score(y_true: np.array, y_score: np.array) -> float:
     """
     Calculate the recall for a ground-truth prediction vector pair.

--- a/rexmex/metrics/classification.py
+++ b/rexmex/metrics/classification.py
@@ -149,6 +149,7 @@ def selectivity(y_true: np.array, y_score: np.array) -> float:
     higher_is_better=True,
     description="TP / (TP + FN)",
     link="https://en.wikipedia.org/wiki/Sensitivity_(test)",
+    binarize=True,
 )
 def true_positive_rate(y_true: np.array, y_score: np.array) -> float:
     """

--- a/rexmex/metrics/classification.py
+++ b/rexmex/metrics/classification.py
@@ -300,6 +300,7 @@ def miss_rate(y_true: np.array, y_score: np.array) -> float:
     higher_is_better=False,
     description="FN / (FN + TP)",
     link="https://en.wikipedia.org/wiki/Type_I_and_type_II_errors#False_positive_and_false_negative_rates",
+    duplicate_of=miss_rate,
 )
 def false_negative_rate(y_true: np.array, y_score: np.array) -> float:
     """
@@ -344,6 +345,7 @@ def fall_out(y_true: np.array, y_score: np.array) -> float:
     higher_is_better=False,
     description="FP / (FP + TN)",
     link="https://en.wikipedia.org/wiki/False_positive_rate",
+    duplicate_of=fall_out,
 )
 def false_positive_rate(y_true: np.array, y_score: np.array) -> float:
     """
@@ -511,6 +513,7 @@ def threat_score(y_true: np.array, y_score: np.array) -> float:
     higher_is_better=True,
     description="TP / (TP + FN + FP)",
     link="https://rexmex.readthedocs.io/en/latest/modules/root.html#rexmex.metrics.classification.threat_score",
+    duplicate_of=threat_score,
 )
 def critical_success_index(y_true: np.array, y_score: np.array) -> float:
     """
@@ -722,6 +725,7 @@ def f1_score(y_true: np.array, y_score: np.array) -> float:
     description="TP / (TP + FP)",
     link="https://en.wikipedia.org/wiki/Positive_predictive_value",
     binarize=True,
+    duplicate_of=positive_predictive_value,
 )
 def precision_score(y_true: np.array, y_score: np.array) -> float:
     """
@@ -745,6 +749,7 @@ def precision_score(y_true: np.array, y_score: np.array) -> float:
     description="TP / (TP + FN)",
     link="https://en.wikipedia.org/wiki/Sensitivity_(test)",
     binarize=True,
+    duplicate_of=true_positive_rate,
 )
 def recall_score(y_true: np.array, y_score: np.array) -> float:
     """

--- a/rexmex/metrics/classification.py
+++ b/rexmex/metrics/classification.py
@@ -99,7 +99,7 @@ def false_negative(y_true: np.array, y_score: np.array) -> float:
 )
 def true_negative_rate(y_true: np.array, y_score: np.array) -> float:
     """
-    Calculate the true negative rate (same as specificity and selectivity).
+    Calculate the true negative rate (duplicated in :func:`specificity` and :func:`selectivity`).
 
     Args:
         y_true (array-like): An N x 1 array of ground truth values.
@@ -114,7 +114,7 @@ def true_negative_rate(y_true: np.array, y_score: np.array) -> float:
 @classifications.duplicate(true_negative_rate)
 def specificity(y_true: np.array, y_score: np.array) -> float:
     """
-    Calculate the specificity (same as selectivity and true negative rate).
+    Calculate the specificity (duplicate of :func:`true_negative_rate`).
 
     Args:
         y_true (array-like): An N x 1 array of ground truth values.
@@ -131,7 +131,7 @@ def specificity(y_true: np.array, y_score: np.array) -> float:
 @classifications.duplicate(true_negative_rate)
 def selectivity(y_true: np.array, y_score: np.array) -> float:
     """
-    Calculate the selectivity (same as specificity and true negative rate).
+    Calculate the selectivity (duplicate of :func:`true_negative_rate`).
 
     Args:
         y_true (array-like): An N x 1 array of ground truth values.
@@ -152,7 +152,7 @@ def selectivity(y_true: np.array, y_score: np.array) -> float:
 )
 def true_positive_rate(y_true: np.array, y_score: np.array) -> float:
     """
-    Calculate the true positive rate (same as recall, sensitivity and hit rate).
+    Calculate the true positive rate (duplicated in :func:`hit_rate`, :func:`sensitivity`, and :func:`recall_score`).
 
     Args:
         y_true (array-like): An N x 1 array of ground truth values.
@@ -167,7 +167,7 @@ def true_positive_rate(y_true: np.array, y_score: np.array) -> float:
 @classifications.duplicate(true_positive_rate)
 def hit_rate(y_true: np.array, y_score: np.array) -> float:
     """
-    Calculate the hit rate (same as recall, sensitivity and true positive rate).
+    Calculate the hit rate (duplicate of :func:`true_positive_rate`).
 
     Args:
         y_true (array-like): An N x 1 array of ground truth values.
@@ -182,7 +182,7 @@ def hit_rate(y_true: np.array, y_score: np.array) -> float:
 @classifications.duplicate(true_positive_rate)
 def sensitivity(y_true: np.array, y_score: np.array) -> float:
     """
-    Calculate the sensitivity (same as recall, hit rate and true positive rate).
+    Calculate the sensitivity (duplicate of :func:`true_positive_rate`).
 
     Args:
         y_true (array-like): An N x 1 array of ground truth values.
@@ -196,6 +196,24 @@ def sensitivity(y_true: np.array, y_score: np.array) -> float:
     return tpr
 
 
+@classifications.duplicate(true_positive_rate, name="Recall")
+def recall_score(y_true: np.array, y_score: np.array) -> float:
+    """
+    Calculate the recall for a ground-truth prediction vector pair.
+
+    Duplicate of :func:`true_positive_rate`, but with alternate
+    implementation from :mod:`sklearn`.
+
+    Args:
+        y_true (array-like): An N x 1 array of ground truth values.
+        y_score (array-like):  An N x 1 array of predicted values.
+    Returns:
+        recall (float): The value of recall.
+    """
+    recall = sklearn.metrics.recall_score(y_true, y_score)
+    return recall
+
+
 @classifications.annotate(
     lower=0.0,
     upper=1.0,
@@ -206,7 +224,7 @@ def sensitivity(y_true: np.array, y_score: np.array) -> float:
 )
 def positive_predictive_value(y_true: np.array, y_score: np.array) -> float:
     """
-    Calculate the positive predictive value (same as precision).
+    Calculate the positive predictive value (duplicated in :func:`precision_score`).
 
     Args:
         y_true (array-like): An N x 1 array of ground truth values.
@@ -223,6 +241,24 @@ def positive_predictive_value(y_true: np.array, y_score: np.array) -> float:
     return ppv
 
 
+@classifications.duplicate(positive_predictive_value, name="Precision")
+def precision_score(y_true: np.array, y_score: np.array) -> float:
+    """
+    Calculate the precision for a ground-truth prediction vector pair.
+
+    Duplicate of :func:`positive_predictive_value`, but with an
+    alternate implementation using :mod:`sklearn`.
+
+    Args:
+        y_true (array-like): An N x 1 array of ground truth values.
+        y_score (array-like):  An N x 1 array of predicted values.
+    Returns:
+        precision (float): The value of precision.
+    """
+    precision = sklearn.metrics.precision_score(y_true, y_score)
+    return precision
+
+
 @classifications.annotate(
     lower=0.0,
     upper=1.0,
@@ -232,7 +268,7 @@ def positive_predictive_value(y_true: np.array, y_score: np.array) -> float:
 )
 def negative_predictive_value(y_true: np.array, y_score: np.array) -> float:
     """
-    Calculate the negative predictive value (same as precision).
+    Calculate the negative predictive value (duplicted in :func:`precision_score`).
 
     Args:
         y_true (array-like): An N x 1 array of ground truth values.
@@ -255,7 +291,7 @@ def negative_predictive_value(y_true: np.array, y_score: np.array) -> float:
 )
 def false_negative_rate(y_true: np.array, y_score: np.array) -> float:
     """
-    Calculate the false negative rate (same as miss rate).
+    Calculate the false negative rate (duplicated in :func:`miss_rate`).
 
     Args:
         y_true (array-like): An N x 1 array of ground truth values.
@@ -293,7 +329,7 @@ def miss_rate(y_true: np.array, y_score: np.array) -> float:
 )
 def false_positive_rate(y_true: np.array, y_score: np.array) -> float:
     """
-    Calculate the false positive rate (same as fall out).
+    Calculate the false positive rate (duplicated in :func:`false_positive_rate`).
 
     Args:
         y_true (array-like): An N x 1 array of ground truth values.
@@ -669,39 +705,6 @@ def f1_score(y_true: np.array, y_score: np.array) -> float:
     """
     f1 = sklearn.metrics.f1_score(y_true, y_score)
     return f1
-
-
-@classifications.duplicate(
-    positive_predictive_value,
-    name="Precision",
-)
-def precision_score(y_true: np.array, y_score: np.array) -> float:
-    """
-    Calculate the precision for a ground-truth prediction vector pair.
-
-    Args:
-        y_true (array-like): An N x 1 array of ground truth values.
-        y_score (array-like):  An N x 1 array of predicted values.
-    Returns:
-        precision (float): The value of precision.
-    """
-    precision = sklearn.metrics.precision_score(y_true, y_score)
-    return precision
-
-
-@classifications.duplicate(true_positive_rate, name="Recall")
-def recall_score(y_true: np.array, y_score: np.array) -> float:
-    """
-    Calculate the recall for a ground-truth prediction vector pair.
-
-    Args:
-        y_true (array-like): An N x 1 array of ground truth values.
-        y_score (array-like):  An N x 1 array of predicted values.
-    Returns:
-        recall (float): The value of recall.
-    """
-    recall = sklearn.metrics.recall_score(y_true, y_score)
-    return recall
 
 
 @classifications.annotate(

--- a/rexmex/utils.py
+++ b/rexmex/utils.py
@@ -101,7 +101,7 @@ class Annotator:
 
         return _wrapper
 
-    def duplicate(self, other, *, name: Optional[str] = None):
+    def duplicate(self, other, *, name: Optional[str] = None, binarize: Optional[bool] = None):
         """Annotate a function as a duplicate."""
         return self.annotate(
             name=name,
@@ -111,7 +111,8 @@ class Annotator:
             upper_inclusive=other.upper_inclusive,
             link=other.link,
             description=other.description,
-            binarize=other.binarize,
             duplicate_of=other,
             higher_is_better=other.higher_is_better,
+            # need to be able to override for sklearn functions
+            binarize=binarize if binarize is not None else other.binarize,
         )

--- a/rexmex/utils.py
+++ b/rexmex/utils.py
@@ -75,6 +75,7 @@ class Annotator:
         lower_inclusive: bool = True,
         upper_inclusive: bool = True,
         binarize: bool = False,
+        duplicate_of: Optional[Metric] = None
     ):
         """Annotate a classification function."""
 
@@ -88,6 +89,7 @@ class Annotator:
             func.link = link
             func.description = description
             func.binarize = binarize
+            func.duplicate_of = duplicate_of
             return func
 
         return _wrapper

--- a/rexmex/utils.py
+++ b/rexmex/utils.py
@@ -83,7 +83,7 @@ class Annotator:
         binarize: bool = False,
         duplicate_of: Optional[Metric] = None,
     ):
-        """Annotate a classification function."""
+        """Annotate a function."""
 
         def _wrapper(func):
             self.funcs[func.__name__] = func
@@ -100,3 +100,25 @@ class Annotator:
             return func
 
         return _wrapper
+
+    def duplicate(
+        self,
+        other,
+        *,
+        name: Optional[str] = None
+    ):
+        """Annotate a function as a duplicate."""
+        return self.annotate(
+            name=name,
+            lower=other.lower,
+            lower_inclusive=other.lower_inclusive,
+            upper=other.upper,
+            upper_inclusive=other.upper_inclusive,
+            link=other.link,
+            description=other.description,
+            binarize=other.binarize,
+            duplicate_of=other,
+            higher_is_better=other.higher_is_better,
+        )
+
+

--- a/rexmex/utils.py
+++ b/rexmex/utils.py
@@ -75,7 +75,7 @@ class Annotator:
         lower_inclusive: bool = True,
         upper_inclusive: bool = True,
         binarize: bool = False,
-        duplicate_of: Optional[Metric] = None
+        duplicate_of: Optional[Metric] = None,
     ):
         """Annotate a classification function."""
 

--- a/rexmex/utils.py
+++ b/rexmex/utils.py
@@ -101,12 +101,7 @@ class Annotator:
 
         return _wrapper
 
-    def duplicate(
-        self,
-        other,
-        *,
-        name: Optional[str] = None
-    ):
+    def duplicate(self, other, *, name: Optional[str] = None):
         """Annotate a function as a duplicate."""
         return self.annotate(
             name=name,
@@ -120,5 +115,3 @@ class Annotator:
             duplicate_of=other,
             higher_is_better=other.higher_is_better,
         )
-
-

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-install_requires = ["numpy", "sklearn", "pandas", "scipy", "scikit-learn"]
+install_requires = ["numpy", "sklearn", "pandas<=1.3.5", "scipy", "scikit-learn"]
 
 
 setup_requires = ["pytest-runner"]

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -121,6 +121,9 @@ class TestClassificationMetrics(unittest.TestCase):
 
     def test_sensitivity(self):
         assert not sensitivity.binarize
+        assert hit_rate.duplicate_of == true_positive_rate
+        assert sensitivity.duplicate_of == true_positive_rate
+        assert true_positive_rate.duplicate_of is None
         assert sensitivity(self.y_true, self.y_score) == 4 / 6
         assert hit_rate(self.y_true, self.y_score) == 4 / 6
         assert true_positive_rate(self.y_true, self.y_score) == 4 / 6

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -96,6 +96,8 @@ class TestClassificationMetrics(unittest.TestCase):
                 self.assert_hasattr(func, "lower_inclusive", bool)
                 self.assert_hasattr(func, "upper_inclusive", bool)
                 self.assert_hasattr(func, "binarize", bool)
+                self.assertTrue(hasattr(func, "duplicate_of"))
+                self.assertTrue(func.duplicate_of is None or inspect.isfunction(func.duplicate_of))
 
     def assert_hasattr(self, obj, name, cls):
         """Check a function is annotated."""


### PR DESCRIPTION
# Summary
 
As a follow-up to #33, this PR adds a `duplicate_of` annotation to the `rexmex.utils.Annotator` class and begins annotating which functions are duplicate of each other.

~**Caveat** I'm not really happy with the direction of which is the "duplicate" in many cases, e.g., where `miss_rate` is the "canonical" one and "false_negative_rate" is the duplicate~

- [x] Code passes all tests
- [x] Unit tests provided for these changes
- [x] Documentation and docstrings added for these changes
- [x] Check all functions are annotated, and correctly

## Changes 

- Add new annotation `duplicate_of` to `rexmex.utils.Annotator`
- Annotate duplicate functions (e.g., `precision_score` is a duplicate of `positive_predictive_value`)
- Pins `pandas<=1.3.5` since they just put the 1.4 release candidate up on PyPI this morning and it doesn't work with the conda env in the GHA workflow