### PR TITLE
Add function keys and annotate ratings

### DIFF
--- a/rexmex/metrics/classification.py
+++ b/rexmex/metrics/classification.py
@@ -622,8 +622,8 @@ def diagnostic_odds_ratio(y_true: np.array, y_score: np.array) -> float:
 
 
 @classifications.annotate(
-    name="AUC-ROC",
-    key="auc_roc",
+    name="ROC-AUC",
+    key="roc_auc",
     lower=0.0,
     upper=1.0,
     higher_is_better=True,
@@ -765,8 +765,8 @@ def matthews_correlation_coefficient(y_true: np.array, y_score: np.array) -> flo
 
 
 @classifications.annotate(
-    name="AUC-PR",
-    key="auc_pr",
+    name="PR-AUC",
+    key="pr_auc",
     lower=0.0,
     upper=1.0,
     higher_is_better=True,

--- a/rexmex/metrics/classification.py
+++ b/rexmex/metrics/classification.py
@@ -625,6 +625,7 @@ def diagnostic_odds_ratio(y_true: np.array, y_score: np.array) -> float:
 
 @classifications.annotate(
     name="AUC-ROC",
+    key="auc_roc",
     lower=0.0,
     upper=1.0,
     higher_is_better=True,
@@ -647,6 +648,7 @@ def roc_auc_score(y_true: np.array, y_score: np.array) -> float:
 
 @classifications.annotate(
     name="Accuracy",
+    key="accuracy",
     lower=0.0,
     upper=1.0,
     higher_is_better=True,
@@ -670,6 +672,7 @@ def accuracy_score(y_true: np.array, y_score: np.array) -> float:
 
 @classifications.annotate(
     name="Balanced accuracy",
+    key="balanced_accuracy",
     lower=0.0,
     upper=1.0,
     higher_is_better=True,
@@ -693,6 +696,7 @@ def balanced_accuracy_score(y_true: np.array, y_score: np.array) -> float:
 
 @classifications.annotate(
     name="F_1",
+    key="f_1",
     lower=0.0,
     upper=1.0,
     higher_is_better=True,
@@ -716,6 +720,7 @@ def f1_score(y_true: np.array, y_score: np.array) -> float:
 
 @classifications.annotate(
     name="Precision",
+    key="precision",
     lower=0.0,
     upper=1.0,
     higher_is_better=True,
@@ -739,6 +744,7 @@ def precision_score(y_true: np.array, y_score: np.array) -> float:
 
 @classifications.annotate(
     name="Recall",
+    key="recall",
     lower=0.0,
     upper=1.0,
     higher_is_better=True,
@@ -762,6 +768,7 @@ def recall_score(y_true: np.array, y_score: np.array) -> float:
 
 @classifications.annotate(
     name="Average precision",
+    key="average_precision",
     lower=0.0,
     upper=1.0,
     higher_is_better=True,
@@ -809,6 +816,7 @@ def matthews_correlation_coefficient(y_true: np.array, y_score: np.array) -> flo
 
 @classifications.annotate(
     name="AUC-PR",
+    key="auc_pr",
     lower=0.0,
     upper=1.0,
     higher_is_better=True,

--- a/rexmex/metrics/classification.py
+++ b/rexmex/metrics/classification.py
@@ -623,6 +623,7 @@ def diagnostic_odds_ratio(y_true: np.array, y_score: np.array) -> float:
 
 @classifications.annotate(
     name="AUC-ROC",
+    key="auc_roc",
     lower=0.0,
     upper=1.0,
     higher_is_better=True,
@@ -645,6 +646,7 @@ def roc_auc_score(y_true: np.array, y_score: np.array) -> float:
 
 @classifications.annotate(
     name="Accuracy",
+    key="accuracy",
     lower=0.0,
     upper=1.0,
     higher_is_better=True,
@@ -668,6 +670,7 @@ def accuracy_score(y_true: np.array, y_score: np.array) -> float:
 
 @classifications.annotate(
     name="Balanced accuracy",
+    key="balanced_accuracy",
     lower=0.0,
     upper=1.0,
     higher_is_better=True,
@@ -691,6 +694,7 @@ def balanced_accuracy_score(y_true: np.array, y_score: np.array) -> float:
 
 @classifications.annotate(
     name="F_1",
+    key="f_1",
     lower=0.0,
     upper=1.0,
     higher_is_better=True,
@@ -714,6 +718,7 @@ def f1_score(y_true: np.array, y_score: np.array) -> float:
 
 @classifications.annotate(
     name="Average precision",
+    key="average_precision",
     lower=0.0,
     upper=1.0,
     higher_is_better=True,
@@ -761,6 +766,7 @@ def matthews_correlation_coefficient(y_true: np.array, y_score: np.array) -> flo
 
 @classifications.annotate(
     name="AUC-PR",
+    key="auc_pr",
     lower=0.0,
     upper=1.0,
     higher_is_better=True,

--- a/rexmex/metrics/rating.py
+++ b/rexmex/metrics/rating.py
@@ -2,7 +2,19 @@ import numpy as np
 import scipy.stats.stats
 import sklearn.metrics
 
+from rexmex.utils import Annotator
 
+ratings = Annotator()
+
+
+@ratings.annotate(
+    key="mse",
+    lower=0.0,
+    upper=float("inf"),
+    higher_is_better=False,
+    link="https://en.wikipedia.org/wiki/Mean_squared_error",
+    description="...",
+)
 def mean_squared_error(y_true: np.array, y_score: np.array) -> float:
     """
     Calculate the mean squared error (MSE) for a ground-truth prediction vector pair.
@@ -17,6 +29,14 @@ def mean_squared_error(y_true: np.array, y_score: np.array) -> float:
     return mse
 
 
+@ratings.annotate(
+    key="mae",
+    lower=0.0,
+    upper=float("inf"),
+    higher_is_better=False,
+    link="https://en.wikipedia.org/wiki/Mean_absolute_error",
+    description="...",
+)
 def mean_absolute_error(y_true: np.array, y_score: np.array) -> float:
     """
     Calculate the mean absolute error (MAE) for a ground-truth prediction vector pair.
@@ -31,6 +51,14 @@ def mean_absolute_error(y_true: np.array, y_score: np.array) -> float:
     return mae
 
 
+@ratings.annotate(
+    key="mape",
+    lower=0.0,
+    upper=100.00,
+    higher_is_better=False,
+    link="https://en.wikipedia.org/wiki/Mean_absolute_percentage_error",
+    description=r"\frac{100}{n} \sum_{t=1}^n \mid \frac{A_t - F_t}{A_t} \mid",
+)
 def mean_absolute_percentage_error(y_true: np.array, y_score: np.array) -> float:
     """
     Calculate the mean absolute percentage error (MAPE) for a ground-truth prediction vector pair.
@@ -45,6 +73,14 @@ def mean_absolute_percentage_error(y_true: np.array, y_score: np.array) -> float
     return mape
 
 
+@ratings.annotate(
+    key="r_squared",
+    lower=0.0,
+    upper=1.0,
+    higher_is_better=True,
+    link="https://en.wikipedia.org/wiki/Coefficient_of_determination",
+    description=r"1 - \frac{\sum_i (y_i - f_i)^2}{\sum_i (y_i - \bar{y})^2}",
+)
 def r2_score(y_true: np.array, y_score: np.array) -> float:
     """
     Calculate the coefficient of determination (R^2) for a ground-truth prediction vector pair.
@@ -59,6 +95,14 @@ def r2_score(y_true: np.array, y_score: np.array) -> float:
     return r2
 
 
+@ratings.annotate(
+    key="pearson_correlation",
+    lower=-1.0,
+    upper=1.0,
+    higher_is_better=True,
+    link="https://en.wikipedia.org/wiki/Pearson_correlation_coefficient",
+    description="...",
+)
 def pearson_correlation_coefficient(y_true: np.array, y_score: np.array) -> float:
     """
     Calculate the Pearson correlation coefficient for a ground-truth prediction vector pair.
@@ -69,10 +113,18 @@ def pearson_correlation_coefficient(y_true: np.array, y_score: np.array) -> floa
     Returns:
         rho (float): The value of the correlation coefficient.
     """
-    rho = scipy.stats.stats.pearsonr(y_true, y_score)
+    rho, _prob = scipy.stats.stats.pearsonr(y_true, y_score)
     return rho
 
 
+@ratings.annotate(
+    key="rmse",
+    lower=0.0,
+    upper=float("inf"),
+    higher_is_better=False,
+    link="https://en.wikipedia.org/wiki/Root-mean-square_deviation",
+    description="...",
+)
 def root_mean_squared_error(y_true: np.array, y_score: np.array) -> float:
     """
     Calculate the root mean squared error (RMSE) for a ground-truth prediction vector pair.
@@ -87,6 +139,14 @@ def root_mean_squared_error(y_true: np.array, y_score: np.array) -> float:
     return rmse
 
 
+@ratings.annotate(
+    key="smape",
+    lower=0.0,
+    upper=100.0,
+    higher_is_better=False,
+    link="https://en.wikipedia.org/wiki/Symmetric_mean_absolute_percentage_error",
+    description="...",
+)
 def symmetric_mean_absolute_percentage_error(y_true: np.array, y_score: np.array) -> float:
     """
     Calculate the symmetric mean absolute percentage error (SMAPE) for a ground-truth prediction vector pair.

--- a/rexmex/metricset.py
+++ b/rexmex/metricset.py
@@ -85,10 +85,9 @@ class ClassificationMetricSet(MetricSet):
     """
 
     def __init__(self):
-        super().__init__({
-            key: binarize(func) if func.binarize else func
-            for key, func in classifications.funcs.items()
-        })
+        super().__init__(
+            {key: binarize(func) if func.binarize else func for key, func in classifications.funcs.items()}
+        )
 
     def __repr__(self):
         """

--- a/rexmex/metricset.py
+++ b/rexmex/metricset.py
@@ -1,15 +1,7 @@
 from typing import Collection, List, Tuple
 
 from rexmex.metrics.classification import classifications
-from rexmex.metrics.rating import (
-    mean_absolute_error,
-    mean_absolute_percentage_error,
-    mean_squared_error,
-    pearson_correlation_coefficient,
-    r2_score,
-    root_mean_squared_error,
-    symmetric_mean_absolute_percentage_error,
-)
+from rexmex.metrics.rating import ratings
 from rexmex.utils import binarize, normalize
 
 
@@ -118,13 +110,7 @@ class RatingMetricSet(MetricSet):
     """
 
     def __init__(self):
-        self["mae"] = mean_absolute_error
-        self["mse"] = mean_squared_error
-        self["rmse"] = root_mean_squared_error
-        self["mape"] = mean_absolute_percentage_error
-        self["smape"] = symmetric_mean_absolute_percentage_error
-        self["r_squared"] = r2_score
-        self["pearson_correlation"] = pearson_correlation_coefficient
+        super().__init__(ratings.funcs)
 
     def normalize_metrics(self):
         """

--- a/rexmex/metricset.py
+++ b/rexmex/metricset.py
@@ -92,14 +92,10 @@ class ClassificationMetricSet(MetricSet):
     """
 
     def __init__(self):
-        super().__init__()
-        for func in classifications:
-            name = func.__name__
-            if name.endswith("_score"):
-                name = name[: -len("_score")]
-            if func.binarize:
-                func = binarize(func)
-            self[name] = func
+        super().__init__({
+            key: binarize(func) if func.binarize else func
+            for key, func in classifications.funcs.items()
+        })
 
     def __repr__(self):
         """

--- a/rexmex/utils.py
+++ b/rexmex/utils.py
@@ -66,9 +66,6 @@ class Annotator:
     def __init__(self):
         self.funcs = {}
 
-    def __iter__(self):
-        return iter(self.funcs.values())
-
     def annotate(
         self,
         *,
@@ -78,6 +75,7 @@ class Annotator:
         link: str,
         description: str,
         name: Optional[str] = None,
+        key: Optional[str] = None,
         lower_inclusive: bool = True,
         upper_inclusive: bool = True,
         binarize: bool = False,
@@ -85,7 +83,8 @@ class Annotator:
         """Annotate a classification function."""
 
         def _wrapper(func):
-            self.funcs[func.__name__] = func
+            func.key = key or func.__name__
+            self.funcs[func.key] = func
             func.name = name or func.__name__.replace("_", " ").title()
             func.lower = lower
             func.lower_inclusive = lower_inclusive

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-install_requires = ["numpy", "sklearn", "pandas", "scipy", "scikit-learn"]
+install_requires = ["numpy", "sklearn", "pandas<=1.3.5", "scipy", "scikit-learn"]
 
 
 setup_requires = ["pytest-runner"]

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -112,7 +112,7 @@ class TestClassificationMetrics(MetricTestCase):
     def test_annotations(self):
         """Check that all functions in the classification module are annotated."""
         skip = {true_positive, false_positive, false_negative, true_negative}
-        self.assert_annotations(rexmex.metrics.classification)
+        self.assert_annotations(rexmex.metrics.classification, skip=skip)
 
     def test_conditions(self):
         assert condition_positive(self.y_true) == 6

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -64,19 +64,19 @@ from rexmex.metrics.rating import (
 )
 
 
-class TestClassificationMetrics(unittest.TestCase):
-    """
-    Newly defined classification metric behaviour tests.
-    """
+class MetricTestCase(unittest.TestCase):
+    """A mixin with tests for metrics."""
 
-    def setUp(self):
-        self.y_true = np.array([0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0])
-        self.y_score = np.array([1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0])
+    def assert_hasattr(self, obj, name, cls):
+        """Check a function is annotated."""
+        self.assertTrue(hasattr(obj, name), msg=f"{name} is unannotated")
+        self.assertIsInstance(getattr(obj, name), cls)
 
-    def test_annotations(self):
+    def assert_annotations(self, module, skip=None):
         """Check that all functions in the classification module are annotated."""
-        skip = {true_positive, false_positive, false_negative, true_negative}
-        for name, func in rexmex.metrics.classification.__dict__.items():
+        if skip is None:
+            skip = set()
+        for name, func in module.__dict__.items():
             if not inspect.isfunction(func) or func in skip:
                 continue
             parameters = inspect.signature(func).parameters
@@ -97,10 +97,20 @@ class TestClassificationMetrics(unittest.TestCase):
                 self.assert_hasattr(func, "upper_inclusive", bool)
                 self.assert_hasattr(func, "binarize", bool)
 
-    def assert_hasattr(self, obj, name, cls):
-        """Check a function is annotated."""
-        self.assertTrue(hasattr(obj, name), msg=f"{name} is unannotated")
-        self.assertIsInstance(getattr(obj, name), cls)
+
+class TestClassificationMetrics(MetricTestCase):
+    """
+    Newly defined classification metric behaviour tests.
+    """
+
+    def setUp(self):
+        self.y_true = np.array([0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0])
+        self.y_score = np.array([1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0])
+
+    def test_annotations(self):
+        """Check that all functions in the classification module are annotated."""
+        skip = {true_positive, false_positive, false_negative, true_negative}
+        self.assert_annotations(rexmex.metrics.classification)
 
     def test_conditions(self):
         assert condition_positive(self.y_true) == 6
@@ -170,7 +180,7 @@ class TestClassificationMetrics(unittest.TestCase):
         assert diagnostic_odds_ratio(self.y_true, self.y_score) == 6 / 5
 
 
-class TestRatingMetrics(unittest.TestCase):
+class TestRatingMetrics(MetricTestCase):
     """
     Newly defined rating metric behaviour tests.
     """
@@ -178,6 +188,10 @@ class TestRatingMetrics(unittest.TestCase):
     def setUp(self):
         self.y_true = np.array([0, 2, 3])
         self.y_score = np.array([4, 7, 8])
+
+    def test_annotations(self):
+        """Check that all functions in the rating module are annotated."""
+        self.assert_annotations(rexmex.metrics.rating)
 
     def test_metrics(self):
         assert root_mean_squared_error(self.y_true, self.y_score) == 22 ** 0.5


### PR DESCRIPTION
# Summary
 
This PR streamlines generating metric sets and annotates more functions.
 
- [x] Code passes all tests
- [x] Unit tests provided for these changes
- [x] Documentation and docstrings added for these changes

## Changes 

* [x] Update the `rexmex.utils.Annotator` class to include a `key`. If it's not given, this defaults to the function's name. The registry now uses the key instead of the function's name
* [x] Update the metric sets to load the function names directly from the keys in the annotator's dictionary
* [x] Annotate functions in the ratings module
* [x] Generalizes tests to make it easier to test the existence of annotations for ratings, coverage, and rankings
