### PR TITLE
added CoverageScoreCard to init

### DIFF
--- a/rexmex/__init__.py
+++ b/rexmex/__init__.py
@@ -8,4 +8,4 @@ from rexmex.metricset import (  # noqa:F401
     RankingMetricSet,
     RatingMetricSet,
 )
-from rexmex.scorecard import ScoreCard  # noqa:F401
+from rexmex.scorecard import CoverageScoreCard, ScoreCard  # noqa:F401


### PR DESCRIPTION
# Summary
 
_Please provide a high-level summary of the changes for the changes and notes for the reviewers_
 
- [ ] Code passes all tests
- [ ] Unit tests provided for these changes
- [ ] Documentation and docstrings added for these changes

## Changes 

quick fix adding CoverageScoreCard to init, otherwise:

`from rexmex import ClassificationMetricSet, DatasetReader, ScoreCard, CoverageScoreCard `
leads to
`ImportError: cannot import name 'CoverageScoreCard' from 'rexmex' (/Users/kbkz358/Software_local/rexmex/rexmex/__init__.py)`