### PR TITLE
Unfix pandas version in RexMex requirements

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,20 +12,20 @@ on:
 jobs:
     build:
       runs-on: ubuntu-latest
+      defaults:
+        run:
+          shell: bash -l {0}
       steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3.7.12
-      - uses: s-weigand/setup-conda@v1
-        with:
-          activate-conda: true
-          python-version: 3.7
+          miniconda-version: 'latest'
+          python-version: 3.8.13
+          activate-environment: rexmex-ci
       - run: conda --version
       - run: which python
       - name: Run installation.
         run: |
-         conda install -y scipy
          pip install codecov
          pip install pytest
          pip install tox

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-install_requires = ["numpy", "sklearn", "pandas<=1.3.5", "scipy", "scikit-learn"]
+install_requires = ["numpy", "sklearn", "pandas", "scipy", "scikit-learn"]
 
 setup_requires = ["pytest-runner"]
 


### PR DESCRIPTION
# Summary
 
Unfix the pandas version in RexMex requirements. Resolves #52 & #53 
 
- [x] Code passes all tests
- [x] Unit tests provided for these changes
- [x] Documentation and docstrings added for these changes

## Changes 

- Unfix the pandas version
- Improve the CI pipelines method to create environments
- Update CI to use python 3.8 instead of 3.7