### PR TITLE
Remove deprecated sklearn dependency

### DIFF
--- a/docs/requirements_1.txt
+++ b/docs/requirements_1.txt
@@ -2,7 +2,7 @@ tqdm
 numpy
 sphinx==4.0.2
 sphinx_rtd_theme==0.5.2
-sklearn
+scikit-learn
 scipy
 pandas
 six

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-install_requires = ["numpy", "sklearn", "pandas", "scipy", "scikit-learn"]
+install_requires = ["numpy", "pandas", "scipy", "scikit-learn"]
 
 setup_requires = ["pytest-runner"]
 


### PR DESCRIPTION
# Summary
 
Fixes #56 by removing deprecated sklearn dependency.
 
- [x] Code passes all tests
- [x] Unit tests provided for these changes (does not apply)
- [x] Documentation and docstrings added for these changes (does not apply)

## Changes 

* Remove deprecated sklearn dependency