### PR TITLE
Fix the division in the hits@k metric to use the size of the relevant_items 

### DIFF
--- a/rexmex/metrics/ranking.py
+++ b/rexmex/metrics/ranking.py
@@ -224,7 +224,7 @@ def hits_at_k(relevant_items: np.array, recommendation: np.array, k=10):
         if item in relevant_items and item not in recommendation[:i]:
             hits += 1.0
 
-    return hits / len(recommendation)
+    return hits / len(relevant_items)
 
 
 def spearmans_rho(relevant_items: np.array, recommendation: np.array):


### PR DESCRIPTION
This PR fixes the division in the hits@k metric to use the length of the relevant_items rather then the number of recommendations. I believe this metric should capture what fraction of the relevant_items are in the first k elements of the recommendation.

Given the example show below, the current code would return a value of ~0.42, but I believe it should be 1 as all of the items appear within the first 7 recommendations. 
```python

from rexmex.metrics.ranking import hits_at_k
relevant_items = [1,2,3]
recommendation = [2,5,4,1,3,0,6]
hits_at_k(relevant_items, recommendation, k=7)
```
After the change in this PR, the correct result is returned. 